### PR TITLE
support slack 'private groups'

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 import logging
 import logging.config

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# -*- coding: utf8 -*-
 
 from glob import glob
 import imp

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -1,4 +1,4 @@
-#coding: UTF-8
+# -*- coding: utf8 -*-
 
 from glob import glob
 import logging

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -65,7 +65,7 @@ class MessageDispatcher(object):
         text = msg.get('text', '')
         channel = msg['channel']
 
-        if channel[0] == 'C':
+        if channel[0] == 'C' or channel[0] == 'G':
             m = AT_MESSAGE_MATCHER.match(text)
             if not m:
                 return
@@ -111,12 +111,12 @@ class Message(object):
         return self._client.find_user_by_name(self._body['username'])
 
     def _gen_at_message(self, text):
-        text = '<@%s>: %s' % (self._get_user_id(), text)
+        text = '<@{}>: {}'.format(self._get_user_id(), text)
         return text
 
     def reply(self, text):
         chan = self._body['channel']
-        if chan.startswith('C'):
+        if chan.startswith('C') or chan.startswith('G'):
             text = self._gen_at_message(text)
         self._client.rtm_send_message(
             self._body['channel'], to_utf8(text))

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -1,3 +1,5 @@
+# -*- coding: utf8 -*-
+
 from __future__ import print_function
 import os
 import json

--- a/slackbot/utils.py
+++ b/slackbot/utils.py
@@ -1,4 +1,5 @@
-#coding: UTF-8
+# -*- coding: utf8 -*-
+
 import os
 import logging
 import tempfile


### PR DESCRIPTION
Private groups have a channel header that isn't handled by slackbot. I've added support so that they're treated like a public channel.
