### PR TITLE
Show command patterns in "bad command" reply

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -94,7 +94,7 @@ class MessageDispatcher(object):
         default_reply = [
             u'Bad command "%s", You can ask me one of the following questions:\n' % msg['text'],
         ]
-        default_reply += [u'    • %s' % str(f.__name__) for f in self._plugins.commands.itervalues()]
+        default_reply += [u'    • `%s`' % str(p.pattern) for p in self._plugins.commands.iterkeys()]
 
         self._client.rtm_send_message(msg['channel'],
                                      '\n'.join(to_utf8(default_reply)))


### PR DESCRIPTION
When bot doesn't understad command it currently shows the names of the command functions it supports, the problem is that most of the time the function name doesn't really gives an idea of what the command really looks like.

I propose to show the pattern that triggers the commands so the user can see what's wrong with the question.

Basically I propose to replace this:

```
willtestBOT [6:08 PM] 
Bad command "hollo", You can ask me one of the following questions:

   • hear_love_direct
   • deploy_command
   • hello
   • deploy_ready_command
   • destroy_command
   • setup_bot
```

for this:

```
willtestBOT [6:09 PM] 
Bad command "hollo", You can ask me one of the following questions:

   • `^deploy (?P<appname>[-\w]+) (?P<branch>[-\w.]+) (?P<version>[-\w.]+)`
   • `(hello|hi)`
   • `i love you`
   • `^deploy ready?`
   • `^destroy (?P<appname>[-\w]+) (?P<branch>[-\w.]+)`
   • `^setup
```
