### PR TITLE
Add @listen_to decorator, answers by multiple plugins, message formatting

### DIFF
--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -42,7 +42,7 @@ class Bot(object):
             self._client.ping()
 
 class PluginsManager(object):
-    commands = { 'respond_to': {}, 'subscribe_to': {} }
+    commands = { 'respond_to': {}, 'listen_to': {} }
 
     def __init__(self):
         pass
@@ -88,9 +88,9 @@ def respond_to(matchstr, flags=0):
         return func
     return wrapper
 
-def subscribe_to(matchstr, flags=0):
+def listen_to(matchstr, flags=0):
     def wrapper(func):
-        PluginsManager.commands['subscribe_to'][re.compile(matchstr, flags)] = func
-        logger.info('registered subscribe_to plugin "%s" to "%s"', func.__name__, matchstr)
+        PluginsManager.commands['listen_to'][re.compile(matchstr, flags)] = func
+        logger.info('registered listen_to plugin "%s" to "%s"', func.__name__, matchstr)
         return func
     return wrapper

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -38,7 +38,7 @@ class Bot(object):
             self._client.ping()
 
 class PluginsManager(object):
-    commands = {}
+    commands = { 'respond_to': {}, 'subscribe_to': {} }
 
     def __init__(self):
         pass
@@ -66,16 +66,27 @@ class PluginsManager(object):
             except:
                 logger.exception('Failed to import %s', module)
 
-    def get_plugin(self, text):
-        for matcher in self.commands:
-            m = matcher.match(text)
+    def get_plugins(self, category, text):
+        hasMatch = False
+        for matcher in self.commands[category]:
+            m = matcher.search(text)
             if m:
-                return self.commands[matcher], to_utf8(m.groups())
-        return None, None
+                hasMatch = True
+                yield self.commands[category][matcher], to_utf8(m.groups())
+
+        if not hasMatch:
+            yield None, None
 
 def respond_to(matchstr, flags=0):
     def wrapper(func):
-        PluginsManager.commands[re.compile(matchstr, flags)] = func
-        logger.info('registered plugin "%s" to "%s"', func.__name__, matchstr)
+        PluginsManager.commands['respond_to'][re.compile(matchstr, flags)] = func
+        logger.info('registered respond_to plugin "%s" to "%s"', func.__name__, matchstr)
+        return func
+    return wrapper
+
+def subscribe_to(matchstr, flags=0):
+    def wrapper(func):
+        PluginsManager.commands['subscribe_to'][re.compile(matchstr, flags)] = func
+        logger.info('registered subscribe_to plugin "%s" to "%s"', func.__name__, matchstr)
         return func
     return wrapper

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -19,7 +19,11 @@ logger = logging.getLogger(__name__)
 
 class Bot(object):
     def __init__(self):
-        self._client = SlackClient(settings.API_TOKEN, settings.BOT_EMOJI)
+        self._client = SlackClient(
+            settings.API_TOKEN,
+            bot_icon = settings.BOT_ICON if hasattr(settings, 'BOT_ICON') else None,
+            bot_emoji = settings.BOT_EMOJI if hasattr(settings, 'BOT_EMOJI') else None
+            )
         self._plugins = PluginsManager()
         self._dispatcher = MessageDispatcher(self._client, self._plugins)
 

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class Bot(object):
     def __init__(self):
-        self._client = SlackClient(settings.API_TOKEN)
+        self._client = SlackClient(settings.API_TOKEN, settings.BOT_EMOJI)
         self._plugins = PluginsManager()
         self._dispatcher = MessageDispatcher(self._client, self._plugins)
 

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -28,18 +28,18 @@ class MessageDispatcher(object):
         msg = msg[1]
         text = msg['text']
         for func, args in self._plugins.get_plugins(category, text):
-        if not func:
+            if not func:
                 if category == 'respond_to':
-            self._default_reply(msg)
-        else:
-            try:
-                func(Message(self._client, msg), *args)
-            except:
-                logger.exception('failed to handle message %s with plugin "%s"', text, func.__name__)
-                reply = '[%s] I have problem when handling "%s"\n' % (func.__name__, text)
-                reply += '```\n%s\n```' % traceback.format_exc()
+                    self._default_reply(msg)
+            else:
+                try:
+                    func(Message(self._client, msg), *args)
+                except:
+                    logger.exception('failed to handle message %s with plugin "%s"', text, func.__name__)
+                    reply = '[%s] I have problem when handling "%s"\n' % (func.__name__, text)
+                    reply += '```\n%s\n```' % traceback.format_exc()
                 self._client.rtm_send_message(msg['channel'], reply)
-            return
+                    return
 
     def _on_new_message(self, msg):
         # ignore edits
@@ -123,9 +123,16 @@ class Message(object):
         chan = self._body['channel']
         if chan.startswith('C') or chan.startswith('G'):
             text = self._gen_at_message(text)
-        self._client.rtm_send_message(
+        self.send(text)
+
+    def send(self, text):
+        self._client.send_message(
             self._body['channel'], to_utf8(text))
 
     @property
     def channel(self):
         return self._client.get_channel(self._body['channel'])
+
+    @property
+    def body(self):
+        return self._body

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -39,7 +39,6 @@ class MessageDispatcher(object):
                     reply = '[%s] I have problem when handling "%s"\n' % (func.__name__, text)
                     reply += '```\n%s\n```' % traceback.format_exc()
                     self._client.rtm_send_message(msg['channel'], reply)
-                return
 
     def _on_new_message(self, msg):
         # ignore edits

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -38,8 +38,8 @@ class MessageDispatcher(object):
                     logger.exception('failed to handle message %s with plugin "%s"', text, func.__name__)
                     reply = '[%s] I have problem when handling "%s"\n' % (func.__name__, text)
                     reply += '```\n%s\n```' % traceback.format_exc()
-                self._client.rtm_send_message(msg['channel'], reply)
-                    return
+                    self._client.rtm_send_message(msg['channel'], reply)
+                return
 
     def _on_new_message(self, msg):
         # ignore edits

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -6,6 +6,10 @@ PLUGINS = [
     'slackbot.plugins',
 ]
 
+#API_TOKEN = '###token###'
+#BOT_ICON = 'http://lorempixel.com/64/64/abstract/7/'
+#BOT_EMOJI = ':godmode:'
+
 for key in os.environ:
     if key[:9] == 'SLACKBOT_':
         name = key[9:]

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -16,8 +16,9 @@ from slackbot.utils import to_utf8
 logger = logging.getLogger(__name__)
 
 class SlackClient(object):
-    def __init__(self, token, connect=True):
+    def __init__(self, token, emoji, connect=True):
         self.token = token
+        self.emoji = emoji
         self.username = None
         self.domain = None
         self.login_data = None
@@ -93,7 +94,7 @@ class SlackClient(object):
         return data
 
     def rtm_send_message(self, channel, message):
-        message_json = {'type': 'message', 'channel': channel, 'text': message}
+        message_json = {'type': 'message', 'channel': channel, 'text': message }
         self.send_to_websocket(message_json)
 
     def upload_file(self, channel, fname, fpath, comment):
@@ -103,9 +104,8 @@ class SlackClient(object):
                                  filename=fname,
                                  initial_comment=comment)
 
-    def send_channel_message(self, channel, message):
-        message_json = {'type': 'message', 'channel': channel, 'text': message}
-        self.send_to_websocket(message_json)
+    def send_message(self, channel, message):
+        self.webapi.chat.post_message(channel, message, username = self.login_data['self']['name'], icon_emoji = self.emoji)
 
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -16,9 +16,10 @@ from slackbot.utils import to_utf8
 logger = logging.getLogger(__name__)
 
 class SlackClient(object):
-    def __init__(self, token, emoji, connect=True):
+    def __init__(self, token, bot_icon = None, bot_emoji = None, connect=True):
         self.token = token
-        self.emoji = emoji
+        self.bot_icon = bot_icon
+        self.bot_emoji = bot_emoji
         self.username = None
         self.domain = None
         self.login_data = None
@@ -105,7 +106,7 @@ class SlackClient(object):
                                  initial_comment=comment)
 
     def send_message(self, channel, message):
-        self.webapi.chat.post_message(channel, message, username = self.login_data['self']['name'], icon_emoji = self.emoji)
+        self.webapi.chat.post_message(channel, message, username = self.login_data['self']['name'], icon_url = self.bot_icon, icon_emoji = self.bot_emoji)
 
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])


### PR DESCRIPTION
- Added @listen_to decorator. With this new decorator, the bot listens all messages on channels where he's invited and can send responses
- Use webapi to send message (and keep rtm send message) to be able to format message (rtm API doesn't allow to format messages)
- Add support for bot icon (required when using webapi send message)
- Allow several plugins to respond (and not only the first matching plugin)
