### PR TITLE
Added @listen_to decorator + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,26 @@ Now you can talk to your bot in your slack client!
 
 A chat bot is meaningless unless you can extend/customize it to fit your own use cases.
 
-To write a new plugin, simplely create a function decorated by `slackbot.bot.respond_to`:
+To write a new plugin, simplely create a function decorated by `slackbot.bot.respond_to` or `slackbot.bot.listen_to`:
+
+- A function decorated with `respond_to` is called when a message matching the pattern is sent to the bot (direct message or @botname in a channel/group chat)
+- A function decorated with `listen_to` is called when a message matching the pattern is sent on a channel/group chat (not directly sent to the bot)
 
 ```python
 from slackbot.bot import respond_to
+from slackbot.bot import listen_to
 
 @respond_to('I love you')
 def love(message):
     message.reply('I love you too!')
+
+@listen_to('Can someone help me?')
+def help(message):
+    # Message is replied to the sender (prefixed with @user)
+    message.reply('Yes, I can!')
+
+    # Message is sent on the channel
+    # message.send('I can help everybody!')
 ```
 
 To extract params from the message, you can use regular expression:

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -42,7 +42,7 @@ class Bot(object):
             self._client.ping()
 
 class PluginsManager(object):
-    commands = { 'respond_to': {}, 'subscribe_to': {} }
+    commands = { 'respond_to': {}, 'listen_to': {} }
 
     def __init__(self):
         pass
@@ -88,9 +88,9 @@ def respond_to(matchstr, flags=0):
         return func
     return wrapper
 
-def subscribe_to(matchstr, flags=0):
+def listen_to(matchstr, flags=0):
     def wrapper(func):
-        PluginsManager.commands['subscribe_to'][re.compile(matchstr, flags)] = func
-        logger.info('registered subscribe_to plugin "%s" to "%s"', func.__name__, matchstr)
+        PluginsManager.commands['listen_to'][re.compile(matchstr, flags)] = func
+        logger.info('registered listen_to plugin "%s" to "%s"', func.__name__, matchstr)
         return func
     return wrapper

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -38,7 +38,7 @@ class Bot(object):
             self._client.ping()
 
 class PluginsManager(object):
-    commands = {}
+    commands = { 'respond_to': {}, 'subscribe_to': {} }
 
     def __init__(self):
         pass
@@ -66,16 +66,27 @@ class PluginsManager(object):
             except:
                 logger.exception('Failed to import %s', module)
 
-    def get_plugin(self, text):
-        for matcher in self.commands:
-            m = matcher.match(text)
+    def get_plugins(self, category, text):
+        hasMatch = False
+        for matcher in self.commands[category]:
+            m = matcher.search(text)
             if m:
-                return self.commands[matcher], to_utf8(m.groups())
-        return None, None
+                hasMatch = True
+                yield self.commands[category][matcher], to_utf8(m.groups())
+
+        if not hasMatch:
+            yield None, None
 
 def respond_to(matchstr, flags=0):
     def wrapper(func):
-        PluginsManager.commands[re.compile(matchstr, flags)] = func
-        logger.info('registered plugin "%s" to "%s"', func.__name__, matchstr)
+        PluginsManager.commands['respond_to'][re.compile(matchstr, flags)] = func
+        logger.info('registered respond_to plugin "%s" to "%s"', func.__name__, matchstr)
+        return func
+    return wrapper
+
+def subscribe_to(matchstr, flags=0):
+    def wrapper(func):
+        PluginsManager.commands['subscribe_to'][re.compile(matchstr, flags)] = func
+        logger.info('registered subscribe_to plugin "%s" to "%s"', func.__name__, matchstr)
         return func
     return wrapper

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -19,7 +19,11 @@ logger = logging.getLogger(__name__)
 
 class Bot(object):
     def __init__(self):
-        self._client = SlackClient(settings.API_TOKEN, settings.BOT_EMOJI)
+        self._client = SlackClient(
+            settings.API_TOKEN,
+            bot_icon = settings.BOT_ICON if hasattr(settings, 'BOT_ICON') else None,
+            bot_emoji = settings.BOT_EMOJI if hasattr(settings, 'BOT_EMOJI') else None
+            )
         self._plugins = PluginsManager()
         self._dispatcher = MessageDispatcher(self._client, self._plugins)
 

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -6,16 +6,16 @@ import importlib
 import logging
 import os
 import re
-import sys
 import thread
 import time
 
 from slackbot import settings
 from slackbot.slackclient import SlackClient
-from slackbot.utils import to_utf8, to_unicode, WorkerPool
+from slackbot.utils import to_utf8
 from slackbot.dispatcher import MessageDispatcher
 
 logger = logging.getLogger(__name__)
+
 
 class Bot(object):
     def __init__(self):
@@ -40,6 +40,7 @@ class Bot(object):
         while True:
             time.sleep(30 * 60)
             self._client.ping()
+
 
 class PluginsManager(object):
     commands = {
@@ -74,15 +75,16 @@ class PluginsManager(object):
                 logger.exception('Failed to import %s', module)
 
     def get_plugins(self, category, text):
-        hasMatch = False
+        has_matching_plugin = False
         for matcher in self.commands[category]:
             m = matcher.search(text)
             if m:
-                hasMatch = True
+                has_matching_plugin = True
                 yield self.commands[category][matcher], to_utf8(m.groups())
 
-        if not hasMatch:
+        if not has_matching_plugin:
             yield None, None
+
 
 def respond_to(matchstr, flags=0):
     def wrapper(func):
@@ -90,6 +92,7 @@ def respond_to(matchstr, flags=0):
         logger.info('registered respond_to plugin "%s" to "%s"', func.__name__, matchstr)
         return func
     return wrapper
+
 
 def listen_to(matchstr, flags=0):
     def wrapper(func):

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class Bot(object):
     def __init__(self):
-        self._client = SlackClient(settings.API_TOKEN)
+        self._client = SlackClient(settings.API_TOKEN, settings.BOT_EMOJI)
         self._plugins = PluginsManager()
         self._dispatcher = MessageDispatcher(self._client, self._plugins)
 

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -135,7 +135,8 @@ class Message(object):
 
             (This function supports formatted message
             when using a bot integration)
-        """        text = self._gen_reply(text)
+        """
+        text = self._gen_reply(text)
         self.send_webapi(text)
 
     def send_webapi(self, text):

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -134,14 +134,6 @@ class Message(object):
         self.send(text)
 
     def send(self, text):
-        self._client.send_message(
-            self._body['channel'], to_utf8(text))
-
-    def rtm_reply(self, text):
-        text = self._gen_reply(text)
-        self.send_rtm(text)
-
-    def rtm_send(self, text):
         self._client.rtm_send_message(
             self._body['channel'], to_utf8(text))
 

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -28,18 +28,18 @@ class MessageDispatcher(object):
         msg = msg[1]
         text = msg['text']
         for func, args in self._plugins.get_plugins(category, text):
-        if not func:
+            if not func:
                 if category == 'respond_to':
-            self._default_reply(msg)
-        else:
-            try:
-                func(Message(self._client, msg), *args)
-            except:
-                logger.exception('failed to handle message %s with plugin "%s"', text, func.__name__)
-                reply = '[%s] I have problem when handling "%s"\n' % (func.__name__, text)
-                reply += '```\n%s\n```' % traceback.format_exc()
+                    self._default_reply(msg)
+            else:
+                try:
+                    func(Message(self._client, msg), *args)
+                except:
+                    logger.exception('failed to handle message %s with plugin "%s"', text, func.__name__)
+                    reply = '[%s] I have problem when handling "%s"\n' % (func.__name__, text)
+                    reply += '```\n%s\n```' % traceback.format_exc()
                 self._client.rtm_send_message(msg['channel'], reply)
-            return
+                    return
 
     def _on_new_message(self, msg):
         # ignore edits
@@ -123,9 +123,16 @@ class Message(object):
         chan = self._body['channel']
         if chan.startswith('C') or chan.startswith('G'):
             text = self._gen_at_message(text)
-        self._client.rtm_send_message(
+        self.send(text)
+
+    def send(self, text):
+        self._client.send_message(
             self._body['channel'], to_utf8(text))
 
     @property
     def channel(self):
         return self._client.get_channel(self._body['channel'])
+
+    @property
+    def body(self):
+        return self._body

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -39,7 +39,6 @@ class MessageDispatcher(object):
                     reply = '[%s] I have problem when handling "%s"\n' % (func.__name__, text)
                     reply += '```\n%s\n```' % traceback.format_exc()
                     self._client.rtm_send_message(msg['channel'], reply)
-                return
 
     def _on_new_message(self, msg):
         # ignore edits

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -139,7 +139,7 @@ class Message(object):
         text = self._gen_reply(text)
         self.send_webapi(text)
 
-    def send_webapi(self, text):
+    def send_webapi(self, text, attachments=None):
         """
             Send a reply using Web API
 
@@ -147,7 +147,9 @@ class Message(object):
             when using a bot integration)
         """
         self._client.send_message(
-            self._body['channel'], to_utf8(text))
+            self._body['channel'],
+            to_utf8(text),
+            attachments=attachments)
 
     def reply(self, text):
         """

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -38,8 +38,8 @@ class MessageDispatcher(object):
                     logger.exception('failed to handle message %s with plugin "%s"', text, func.__name__)
                     reply = '[%s] I have problem when handling "%s"\n' % (func.__name__, text)
                     reply += '```\n%s\n```' % traceback.format_exc()
-                self._client.rtm_send_message(msg['channel'], reply)
-                    return
+                    self._client.rtm_send_message(msg['channel'], reply)
+                return
 
     def _on_new_message(self, msg):
         # ignore edits

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -1,10 +1,7 @@
 # -*- coding: utf8 -*-
 
-from glob import glob
 import logging
-import os
 import re
-import sys
 import time
 import traceback
 
@@ -13,6 +10,7 @@ from slackbot.utils import to_utf8, WorkerPool
 logger = logging.getLogger(__name__)
 
 AT_MESSAGE_MATCHER = re.compile(r'^\<@(\w+)\>:? (.*)$')
+
 
 class MessageDispatcher(object):
     def __init__(self, slackclient, plugins):
@@ -42,7 +40,6 @@ class MessageDispatcher(object):
         if responded is False and category == 'respond_to':
             self._default_reply(msg)
 
-
     def _on_new_message(self, msg):
         # ignore edits
         subtype = msg.get('subtype', '')
@@ -62,12 +59,11 @@ class MessageDispatcher(object):
         if username == botname or username == 'slackbot':
             return
 
-        msgRespondTo = self.filter_text(msg)
-        if msgRespondTo:
-            self._pool.add_task(('respond_to', msgRespondTo))
+        msg_respond_to = self.filter_text(msg)
+        if msg_respond_to:
+            self._pool.add_task(('respond_to', msg_respond_to))
         else:
             self._pool.add_task(('listen_to', msg))
-
 
     def filter_text(self, msg):
         text = msg.get('text', '')
@@ -106,6 +102,7 @@ class MessageDispatcher(object):
 
         self._client.rtm_send_message(msg['channel'],
                                      '\n'.join(to_utf8(default_reply)))
+
 
 class Message(object):
     def __init__(self, slackclient, body):

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -129,11 +129,42 @@ class Message(object):
         else:
             return text
 
+    def reply_webapi(self, text):
+        """
+            Send a reply to the sender using Web API
+
+            (This function supports formatted message
+            when using a bot integration)
+        """        text = self._gen_reply(text)
+        self.send_webapi(text)
+
+    def send_webapi(self, text):
+        """
+            Send a reply using Web API
+
+            (This function supports formatted message
+            when using a bot integration)
+        """
+        self._client.send_message(
+            self._body['channel'], to_utf8(text))
+
     def reply(self, text):
+        """
+            Send a reply to the sender using RTM API
+
+            (This function doesn't supports formatted message
+            when using a bot integration)
+        """
         text = self._gen_reply(text)
         self.send(text)
 
     def send(self, text):
+        """
+            Send a reply using RTM API
+
+            (This function doesn't supports formatted message
+            when using a bot integration)
+        """
         self._client.rtm_send_message(
             self._body['channel'], to_utf8(text))
 

--- a/slackbot/plugins/hello.py
+++ b/slackbot/plugins/hello.py
@@ -2,6 +2,7 @@ from slackbot.bot import respond_to
 from slackbot.bot import listen_to
 import re
 
+
 @respond_to('hello$', re.IGNORECASE)
 def hello_reply(message):
     message.reply('hello sender!')
@@ -16,3 +17,9 @@ def hello_reply_formatting(message):
 @listen_to('hello$')
 def hello_send(message):
     message.send('hello channel!')
+
+
+@listen_to('hello_decorators')
+@respond_to('hello_decorators')
+def hello_decorators(message):
+    message.send('hello!')

--- a/slackbot/plugins/hello.py
+++ b/slackbot/plugins/hello.py
@@ -1,6 +1,18 @@
 from slackbot.bot import respond_to
+from slackbot.bot import listen_to
 import re
 
-@respond_to('hello', re.IGNORECASE)
-def hello(message):
-    message.reply('hello!')
+@respond_to('hello$', re.IGNORECASE)
+def hello_reply(message):
+    message.reply('hello sender!')
+
+
+@respond_to('hello_formatting')
+def hello_reply_formatting(message):
+    # Format message with italic style
+    message.reply('_hello_ sender!')
+
+
+@listen_to('hello$')
+def hello_send(message):
+    message.send('hello channel!')

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -9,9 +9,9 @@ PLUGINS = [
 # API_TOKEN = '###token###'
 
 '''
-If you use Slack Web API to send messages (with send() or reply()),
+If you use Slack Web API to send messages (with send_webapi() or reply_webapi()),
 you can customize the bot logo by providing Icon or Emoji.
-If you use Slack RTM API to send messages (with rtm_send() or rtm_reply()),
+If you use Slack RTM API to send messages (with send() or reply()),
 the used icon comes from bot settings and Icon or Emoji has no effect.
 '''
 # BOT_ICON = 'http://lorempixel.com/64/64/abstract/7/'

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -6,6 +6,10 @@ PLUGINS = [
     'slackbot.plugins',
 ]
 
+#API_TOKEN = '###token###'
+#BOT_ICON = 'http://lorempixel.com/64/64/abstract/7/'
+#BOT_EMOJI = ':godmode:'
+
 for key in os.environ:
     if key[:9] == 'SLACKBOT_':
         name = key[9:]

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -16,8 +16,9 @@ from slackbot.utils import to_utf8
 logger = logging.getLogger(__name__)
 
 class SlackClient(object):
-    def __init__(self, token, connect=True):
+    def __init__(self, token, emoji, connect=True):
         self.token = token
+        self.emoji = emoji
         self.username = None
         self.domain = None
         self.login_data = None
@@ -93,7 +94,7 @@ class SlackClient(object):
         return data
 
     def rtm_send_message(self, channel, message):
-        message_json = {'type': 'message', 'channel': channel, 'text': message}
+        message_json = {'type': 'message', 'channel': channel, 'text': message }
         self.send_to_websocket(message_json)
 
     def upload_file(self, channel, fname, fpath, comment):
@@ -103,9 +104,8 @@ class SlackClient(object):
                                  filename=fname,
                                  initial_comment=comment)
 
-    def send_channel_message(self, channel, message):
-        message_json = {'type': 'message', 'channel': channel, 'text': message}
-        self.send_to_websocket(message_json)
+    def send_message(self, channel, message):
+        self.webapi.chat.post_message(channel, message, username = self.login_data['self']['name'], icon_emoji = self.emoji)
 
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -16,9 +16,10 @@ from slackbot.utils import to_utf8
 logger = logging.getLogger(__name__)
 
 class SlackClient(object):
-    def __init__(self, token, emoji, connect=True):
+    def __init__(self, token, bot_icon = None, bot_emoji = None, connect=True):
         self.token = token
-        self.emoji = emoji
+        self.bot_icon = bot_icon
+        self.bot_emoji = bot_emoji
         self.username = None
         self.domain = None
         self.login_data = None
@@ -105,7 +106,7 @@ class SlackClient(object):
                                  initial_comment=comment)
 
     def send_message(self, channel, message):
-        self.webapi.chat.post_message(channel, message, username = self.login_data['self']['name'], icon_emoji = self.emoji)
+        self.webapi.chat.post_message(channel, message, username = self.login_data['self']['name'], icon_url = self.bot_icon, icon_emoji = self.bot_emoji)
 
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -15,8 +15,9 @@ from slackbot.utils import to_utf8
 
 logger = logging.getLogger(__name__)
 
+
 class SlackClient(object):
-    def __init__(self, token, bot_icon = None, bot_emoji = None, connect=True):
+    def __init__(self, token, bot_icon=None, bot_emoji=None, connect=True):
         self.token = token
         self.bot_icon = bot_icon
         self.bot_emoji = bot_emoji
@@ -111,7 +112,13 @@ class SlackClient(object):
                                  initial_comment=comment)
 
     def send_message(self, channel, message, attachments=None):
-        self.webapi.chat.post_message(channel, message, username = self.login_data['self']['name'], icon_url = self.bot_icon, icon_emoji = self.bot_emoji, attachments = attachments)
+        self.webapi.chat.post_message(
+                channel,
+                message,
+                username=self.login_data['self']['name'],
+                icon_url=self.bot_icon,
+                icon_emoji=self.bot_emoji,
+                attachments=attachments)
 
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])
@@ -121,8 +128,10 @@ class SlackClient(object):
             if user['name'] == username:
                 return userid
 
+
 class SlackConnectionError(Exception):
     pass
+
 
 class Channel(object):
     def __init__(self, slackclient, body):

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -94,8 +94,13 @@ class SlackClient(object):
                 data.append(json.loads(d))
         return data
 
-    def rtm_send_message(self, channel, message):
-        message_json = {'type': 'message', 'channel': channel, 'text': message}
+    def rtm_send_message(self, channel, message, attachments=None):
+        message_json = {
+            'type': 'message',
+            'channel': channel,
+            'text': message,
+            'attachments': attachments
+            }
         self.send_to_websocket(message_json)
 
     def upload_file(self, channel, fname, fpath, comment):
@@ -105,8 +110,8 @@ class SlackClient(object):
                                  filename=fname,
                                  initial_comment=comment)
 
-    def send_message(self, channel, message):
-        self.webapi.chat.post_message(channel, message, username = self.login_data['self']['name'], icon_url = self.bot_icon, icon_emoji = self.bot_emoji)
+    def send_message(self, channel, message, attachments=None):
+        self.webapi.chat.post_message(channel, message, username = self.login_data['self']['name'], icon_url = self.bot_icon, icon_emoji = self.bot_emoji, attachments = attachments)
 
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])

--- a/slackbot/utils.py
+++ b/slackbot/utils.py
@@ -3,7 +3,6 @@
 import os
 import logging
 import tempfile
-import math
 import thread
 import Queue
 import requests
@@ -11,12 +10,13 @@ from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
 
+
 def download_file(url, fpath):
     logger.debug('starting to fetch %s', url)
     r = requests.get(url, stream=True)
     with open(fpath, 'wb') as f:
         for chunk in r.iter_content(chunk_size=1024*64):
-            if chunk: # filter out keep-alive new chunks
+            if chunk:  # filter out keep-alive new chunks
                 f.write(chunk)
                 f.flush()
     logger.debug('fetch %s', fpath)
@@ -43,25 +43,6 @@ def to_utf8(s):
     else:
         return s
 
-def to_unicode(s):
-    """Convert a string to unicode. If the argument is an iterable
-    (list/tuple/set), then each element of it would be converted instead.
-
-    >>> to_unicode('a')
-    u'a'
-    >>> to_unicode(u'a')
-    u'a'
-    >>> to_unicode(['a', 'b', '你'])
-    [u'a', u'b', u'\u4f60']
-    """
-    if isinstance(s, str):
-        return s.decode('utf-8')
-    elif isinstance(s, unicode):
-        return s
-    elif isinstance(s, (list, tuple, set)):
-        return [to_unicode(v) for v in s]
-    else:
-        return s
 
 @contextmanager
 def create_tmp_file(content=''):
@@ -74,18 +55,6 @@ def create_tmp_file(content=''):
         os.close(fd)
         os.remove(name)
 
-def log2(x):
-    return math.log(x, 2)
-
-_suffixes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'EB', 'ZB']
-def readable_file_size(size):
-    # determine binary order in steps of size 10
-    # (coerce to int, // still returns a float)
-    order = int(log2(size) / 10) if size else 0
-    # format file size
-    # (.4g results in rounded numbers for exact matches and max 3 decimals,
-    # should never resort to exponent values)
-    return '{:.4g} {}'.format(size / (1 << (order * 10)), _suffixes[order])
 
 class WorkerPool(object):
     def __init__(self, func, nworker=10):

--- a/tests/functional/driver.py
+++ b/tests/functional/driver.py
@@ -95,6 +95,15 @@ class Driver(object):
                         raise AssertionError(
                             'expected to get message matching "%s", but got message "%s"' % (match, event['text']))
 
+    def ensure_no_channel_reply_from_bot(self, wait=5):
+        for _ in xrange(wait):
+            time.sleep(1)
+            with self._events_lock:
+                for event in self.events:
+                    if self._is_bot_message(event):
+                        raise AssertionError(
+                            'expected to get nothing, but got message "%s"' % event['text'])
+
     def wait_for_file_uploaded(self, name, maxwait=60):
         for _ in xrange(maxwait):
             time.sleep(1)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -56,11 +56,19 @@ def test_bot_get_online(driver): # pylint: disable=W0613
 
 def test_bot_respond_to_simple_message(driver):
     driver.send_direct_message('hello')
-    driver.wait_for_bot_direct_message('hello!')
+    driver.wait_for_bot_direct_message('hello sender!')
+
+def test_bot_respond_to_simple_message_with_formatting(driver):
+    driver.send_direct_message('hello_formatting')
+    driver.wait_for_bot_direct_message('_hello_ sender!')
 
 def test_bot_respond_to_simple_message_case_insensitive(driver):
     driver.send_direct_message('hEllO')
-    driver.wait_for_bot_direct_message('hello!')
+    driver.wait_for_bot_direct_message('hello sender!')
+
+def test_bot_respond_to_simple_message_multiple_plugins(driver):
+    driver.send_direct_message('hello_formatting hello')
+    driver.wait_for_bot_direct_messages({'hello sender!', '_hello_ sender!'})
 
 def test_bot_default_reply(driver):
     driver.send_direct_message('youdontunderstandthiscommand do you')
@@ -80,19 +88,27 @@ def test_bot_upload_file_from_link(driver):
 
 def test_bot_reply_to_channel_message(driver):
     driver.send_channel_message('hello')
-    driver.wait_for_bot_channel_message('hello!')
+    driver.wait_for_bot_channel_message('hello sender!')
     driver.send_channel_message('hello', colon=False)
-    driver.wait_for_bot_channel_message('hello!')
+    driver.wait_for_bot_channel_message('hello sender!')
+
+def test_bot_listen_to_channel_message(driver):
+    driver.send_channel_message('hello', tobot=False)
+    driver.wait_for_bot_channel_message('hello channel!', tosender=False)
 
 def test_bot_reply_to_group_message(driver):
     driver.send_group_message('hello')
-    driver.wait_for_bot_group_message('hello!')
+    driver.wait_for_bot_group_message('hello sender!')
     driver.send_group_message('hello', colon=False)
-    driver.wait_for_bot_group_message('hello!')
+    driver.wait_for_bot_group_message('hello sender!')
 
-def test_bot_ignores_non_related_channel_message(driver):
+def test_bot_ignores_non_related_message_response_tosender(driver):
+    driver.send_channel_message('hello', tobot=True)
+    driver.ensure_only_specificmessage_from_bot('hello sender!', tosender=True)
+
+def test_bot_ignores_non_related_message_response_tochannel(driver):
     driver.send_channel_message('hello', tobot=False)
-    driver.ensure_no_channel_reply_from_bot()
+    driver.ensure_only_specificmessage_from_bot('hello channel!', tosender=False)
 
 @pytest.mark.skipif(not TRAVIS, reason="only run reconnect tests on travis builds") # pylint: disable=E1101
 def test_bot_reconnect(driver):

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -110,6 +110,14 @@ def test_bot_ignores_non_related_message_response_tochannel(driver):
     driver.send_channel_message('hello', tobot=False)
     driver.ensure_only_specificmessage_from_bot('hello channel!', tosender=False)
 
+def test_bot_reply_to_channel_message_multiple_decorators(driver):
+    driver.send_channel_message('hello_decorators')
+    driver.wait_for_bot_channel_message('hello!', tosender=False)
+    driver.send_channel_message('hello_decorators', tobot=False)
+    driver.wait_for_bot_channel_message('hello!', tosender=False)
+    driver.send_direct_message('hello_decorators')
+    driver.wait_for_bot_direct_message('hello!')
+
 @pytest.mark.skipif(not TRAVIS, reason="only run reconnect tests on travis builds") # pylint: disable=E1101
 def test_bot_reconnect(driver):
     driver.wait_for_bot_online()

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -110,6 +110,14 @@ def test_bot_ignores_non_related_message_response_tochannel(driver):
     driver.send_channel_message('hello', tobot=False)
     driver.ensure_only_specificmessage_from_bot('hello channel!', tosender=False)
 
+def test_bot_ignores_unknown_message_noresponse_tochannel(driver):
+    driver.send_channel_message('unknown message', tobot=False)
+    driver.ensure_no_channel_reply_from_bot()
+
+def test_bot_send_usage_unknown_message_response_tosender(driver):
+    driver.send_channel_message('unknown message', tobot=True)
+    driver.ensure_only_specificmessage_from_bot('Bad command "unknown message".+', tosender=False)
+
 def test_bot_reply_to_message_multiple_decorators(driver):
     driver.send_channel_message('hello_decorators')
     driver.wait_for_bot_channel_message('hello!', tosender=False)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -110,7 +110,7 @@ def test_bot_ignores_non_related_message_response_tochannel(driver):
     driver.send_channel_message('hello', tobot=False)
     driver.ensure_only_specificmessage_from_bot('hello channel!', tosender=False)
 
-def test_bot_reply_to_channel_message_multiple_decorators(driver):
+def test_bot_reply_to_message_multiple_decorators(driver):
     driver.send_channel_message('hello_decorators')
     driver.wait_for_bot_channel_message('hello!', tosender=False)
     driver.send_channel_message('hello_decorators', tobot=False)


### PR DESCRIPTION
- Added new decorator @listen_to to listen all messages on subscribed channels
- Added reply_webapi() and send_webapi() functions to use Slack Web API (allow messages formatting when using bot integration)
- Added support for bot_icon and bot_emoji (used by Web API)
- Allowed multiples plugins to be called for the same message
