### PR TITLE
Pull project settings from slackbot_settings.py

### DIFF
--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -23,6 +23,9 @@ for key in os.environ:
         globals()[name] = os.environ[key]
 
 try:
-    from local_settings import *
+    from slackbot_settings import *
 except ImportError:
-    pass
+    try:
+        from local_settings import *
+    except ImportError:
+        pass


### PR DESCRIPTION
When using slackbot as a library the current way to load project settings is by adding a local_settings.py to your projects, this is not that convenient when there are common settings between production and local development environments
