### PR TITLE
fixed a crash that occurred when bot tried to list available commands...

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -98,7 +98,7 @@ class MessageDispatcher(object):
         default_reply = [
             u'Bad command "%s", You can ask me one of the following questions:\n' % msg['text'],
         ]
-        default_reply += [u'    • `%s`' % unicode(p.pattern) for p in self._plugins.commands['respond_to'].iterkeys()]
+        default_reply += [u'    • `{}`'.format(p.pattern) for p in self._plugins.commands['respond_to'].iterkeys()]
 
         self._client.rtm_send_message(msg['channel'],
                                      '\n'.join(to_utf8(default_reply)))
@@ -116,7 +116,7 @@ class Message(object):
         return self._client.find_user_by_name(self._body['username'])
 
     def _gen_at_message(self, text):
-        text = '<@{}>: {}'.format(self._get_user_id(), text)
+        text = u'<@{}>: {}'.format(self._get_user_id(), text)
         return text
 
     def _gen_reply(self, text):

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -98,7 +98,7 @@ class MessageDispatcher(object):
         default_reply = [
             u'Bad command "%s", You can ask me one of the following questions:\n' % msg['text'],
         ]
-        default_reply += [u'    • `%s`' % str(p.pattern) for p in self._plugins.commands['respond_to'].iterkeys()]
+        default_reply += [u'    • `%s`' % unicode(p.pattern) for p in self._plugins.commands['respond_to'].iterkeys()]
 
         self._client.rtm_send_message(msg['channel'],
                                      '\n'.join(to_utf8(default_reply)))


### PR DESCRIPTION
… and there was a unicode pattern in one of the respond_to functions

Example pattern:

```
@respond_to(u'привет', re.IGNORECASE)
def hi_answer(message):
    message.send(u'И тебе привет')
```

The crash traceback was:

```
Traceback (most recent call last):
  File "/Users/datagreed/.venv/marvin/lib/python2.7/site-packages/slackbot/dispatcher.py", line 33, in dispatch_msg
    func(Message(self._client, msg), *args)
  File "/Users/datagreed/Work/personal/Marvin/plugins/love.py", line 40, in generic
    u":sweat:",
  File "/Users/datagreed/.venv/marvin/lib/python2.7/site-packages/slackbot/dispatcher.py", line 158, in reply
    text = self._gen_reply(text)
  File "/Users/datagreed/.venv/marvin/lib/python2.7/site-packages/slackbot/dispatcher.py", line 125, in _gen_reply
    return self._gen_at_message(text)
  File "/Users/datagreed/.venv/marvin/lib/python2.7/site-packages/slackbot/dispatcher.py", line 119, in _gen_at_message
    text = '<@{}>: {}'.format(self._get_user_id(), text)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```
