### PR TITLE
Dispatcher uses doc strings as well as pattern

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -98,8 +98,9 @@ class MessageDispatcher(object):
         default_reply = [
             u'Bad command "%s", You can ask me one of the following questions:\n' % msg['text'],
         ]
-        default_reply += [u'    • `{}`'.format(p.pattern) for p in self._plugins.commands['respond_to'].iterkeys()]
-
+        default_reply += [u'    • `{0}` {1}'.format(p.pattern, v.__doc__ or "") \
+            for p, v in self._plugins.commands['respond_to'].iteritems()]
+            
         self._client.rtm_send_message(msg['channel'],
                                      '\n'.join(to_utf8(default_reply)))
 


### PR DESCRIPTION
Instead of just reporting the pattern used for in the default reply help messages, also reply with docstrings - so for instance a plugin could have some helpful message on usage and what it does.
