### PR TITLE
Fix periodic crash when looking up username in dispatcher.

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -50,7 +50,7 @@ class MessageDispatcher(object):
         try:
             msguser = self._client.users.get(msg['user'])
             username = msguser['name']
-        except KeyError:
+        except (KeyError, TypeError):
             if 'username' in msg:
                 username = msg['username']
             else:


### PR DESCRIPTION
A long-running bot process would occasionally crash w/ a `TypeError`, because `msg` is `None`. I'm uncertain of why `msg=None` in those cases, but I know that I now have a bot process that has been running for well over a month without a crash!
