### PR TITLE
add support for aliases

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -22,7 +22,7 @@ class MessageDispatcher(object):
         self._plugins = plugins
 
         alias_regex = ''
-        if hasattr(settings, 'ALIASES') and settings.ALIASES != '':
+        if getattr(settings, 'ALIASES', None):
             alias_regex = '|(?P<alias>{})'.format('|'.join([re.escape(s) for s in settings.ALIASES.split(',')]))
 
         self.AT_MESSAGE_MATCHER = re.compile(r'^(?:\<@(?P<atuser>\w+)\>{}):? (?P<text>.*)$'.format(alias_regex))

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -11,6 +11,16 @@ PLUGINS = [
 # API_TOKEN = '###token###'
 
 '''
+Setup a comma delimited list of aliases that the bot will respond to.
+
+Example: if you set ALIASES='!,$' then a bot which would respond to:
+'botname hello'
+will now also respond to
+'$ hello'
+'''
+ALIASES = ''
+
+'''
 If you use Slack Web API to send messages (with send_webapi() or reply_webapi()),
 you can customize the bot logo by providing Icon or Emoji.
 If you use Slack RTM API to send messages (with send() or reply()),

--- a/tests/functional/driver.py
+++ b/tests/functional/driver.py
@@ -247,7 +247,7 @@ class Driver(object):
                 break
         else:
             raise RuntimeError('Have you created the private group {} for testing?'.format(
-                self.group_name))
+                self.test_group))
 
     def _invite_testbot_to_channel(self):
         if self.testbot_userid not in self.slacker.channels.info(self.cm_chan).body['channel']['members']:

--- a/tests/functional/settings.py
+++ b/tests/functional/settings.py
@@ -15,6 +15,7 @@ driver_apitoken = None
 driver_username = None
 test_channel = None
 test_group = None
+ALIASES = ",".join(["!", "$"])
 
 for key in KEYS:
     envkey = 'SLACKBOT_' + key.upper()

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -156,3 +156,7 @@ def test_bot_reply_with_unicode_message(driver):
     driver.wait_for_bot_channel_message(u'你好!')
     driver.send_channel_message(u'你不明白，对吗？')
     driver.wait_for_bot_channel_message(u'.*You can ask me.*')
+
+def test_bot_reply_with_alias_message(driver):
+    driver.send_channel_message("! hello", False, False)
+    driver.wait_for_bot_channel_message("hello sender!", tosender=True)

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -1,12 +1,12 @@
 import pytest
 
-aliases = ['!', '$', 'botbro']
-fake_bot_id = 'US99999'
-fake_bot_name = '<@' + fake_bot_id + '>'
+TEST_ALIASES = ['!', '$', 'botbro']
+FAKE_BOT_ID = 'US99999'
+FAKE_BOT_NAME = '<@' + FAKE_BOT_ID + '>'
 
 @pytest.fixture()
 def setup_aliases(monkeypatch):
-    monkeypatch.setattr('slackbot.settings.ALIASES', ','.join(aliases))
+    monkeypatch.setattr('slackbot.settings.ALIASES', ','.join(TEST_ALIASES))
 
 
 @pytest.fixture()
@@ -14,7 +14,7 @@ def dispatcher(monkeypatch):
     from slackbot.dispatcher import MessageDispatcher
 
     def return_fake_bot_id():
-        return fake_bot_id
+        return FAKE_BOT_ID
     dispatcher = MessageDispatcher(None, None)
     monkeypatch.setattr(dispatcher, '_get_bot_id', return_fake_bot_id)
     return dispatcher
@@ -25,7 +25,7 @@ def test_aliases(setup_aliases, dispatcher):
         'channel': 'C99999'
     }
 
-    for a in aliases:
+    for a in TEST_ALIASES:
         msg['text'] = a + ' hello'
         msg = dispatcher.filter_text(msg)
         assert msg['text'] == 'hello'
@@ -45,7 +45,7 @@ def test_nondirectmsg_works(dispatcher):
 
 def test_botname_works(dispatcher):
     msg = {
-        'text': fake_bot_name + ' hello',
+        'text': FAKE_BOT_NAME + ' hello',
         'channel': 'C99999'
     }
 
@@ -55,7 +55,7 @@ def test_botname_works(dispatcher):
 
 def test_botname_works_with_aliases_present(setup_aliases, dispatcher):
     msg = {
-        'text': fake_bot_name + ' hello',
+        'text': FAKE_BOT_NAME + ' hello',
         'channel': 'G99999'
     }
 
@@ -67,7 +67,7 @@ def test_no_aliases_doesnt_work(dispatcher):
     msg = {
         'channel': 'G99999'
     }
-    for a in aliases:
+    for a in TEST_ALIASES:
         text = a + ' hello'
         msg['text'] = text
         assert dispatcher.filter_text(msg) is None
@@ -86,7 +86,7 @@ def test_direct_message(dispatcher):
 
 def test_direct_message_with_name(dispatcher):
     msg = {
-        'text': fake_bot_name + ' hello',
+        'text': FAKE_BOT_NAME + ' hello',
         'channel': 'D99999'
     }
 

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -1,0 +1,94 @@
+import pytest
+
+aliases = ['!', '$', 'botbro']
+fake_bot_id = 'US99999'
+fake_bot_name = '<@' + fake_bot_id + '>'
+
+@pytest.fixture()
+def setup_aliases(monkeypatch):
+    monkeypatch.setattr('slackbot.settings.ALIASES', ','.join(aliases))
+
+
+@pytest.fixture()
+def dispatcher(monkeypatch):
+    from slackbot.dispatcher import MessageDispatcher
+
+    def return_fake_bot_id():
+        return fake_bot_id
+    dispatcher = MessageDispatcher(None, None)
+    monkeypatch.setattr(dispatcher, '_get_bot_id', return_fake_bot_id)
+    return dispatcher
+
+
+def test_aliases(setup_aliases, dispatcher):
+    msg = {
+        'channel': 'C99999'
+    }
+
+    for a in aliases:
+        msg['text'] = a + ' hello'
+        msg = dispatcher.filter_text(msg)
+        assert msg['text'] == 'hello'
+
+
+def test_nondirectmsg_works(dispatcher):
+
+    # the ID of someone that is not the bot
+    other_id = '<@U1111>'
+    msg = {
+        'text': other_id + ' hello',
+        'channel': 'C99999'
+    }
+
+    assert dispatcher.filter_text(msg) is None
+
+
+def test_botname_works(dispatcher):
+    msg = {
+        'text': fake_bot_name + ' hello',
+        'channel': 'C99999'
+    }
+
+    msg = dispatcher.filter_text(msg)
+    assert msg['text'] == 'hello'
+
+
+def test_botname_works_with_aliases_present(setup_aliases, dispatcher):
+    msg = {
+        'text': fake_bot_name + ' hello',
+        'channel': 'G99999'
+    }
+
+    msg = dispatcher.filter_text(msg)
+    assert msg['text'] == 'hello'
+
+
+def test_no_aliases_doesnt_work(dispatcher):
+    msg = {
+        'channel': 'G99999'
+    }
+    for a in aliases:
+        text = a + ' hello'
+        msg['text'] = text
+        assert dispatcher.filter_text(msg) is None
+        assert msg['text'] == text
+
+
+def test_direct_message(dispatcher):
+    msg = {
+        'text': 'hello',
+        'channel': 'D99999'
+    }
+
+    msg = dispatcher.filter_text(msg)
+    assert msg['text'] == 'hello'
+
+
+def test_direct_message_with_name(dispatcher):
+    msg = {
+        'text': fake_bot_name + ' hello',
+        'channel': 'D99999'
+    }
+
+    msg = dispatcher.filter_text(msg)
+    assert msg['text'] == 'hello'


### PR DESCRIPTION
Hey @lins05, thanks for the work on the awesome bot.  We're (Magfest) attempting to use it for devops purposes and shenanigans to replace our existing bot, which is Hubot-based, with a python bot (because we're a python shop mostly).  This will be the first pull request of a few that we're currently working on which is designed to mimic some features that Hubot has which our chat has become used to.  I'm going to try and clean these changes up with the hope of pulling them into your upstream repo.

---

This PR:
You can use shorthand notation or aliases for talking to the bot now.  This allows `slackbot.settings.ALIASES` to take a comma-delimited list of aliases the bot will respond to.

For example, normally you'd have to do:

```
@botuser hello
```

but if you add this env var / add to settings.py:

```
export SLACKBOT_ALIASES='!,$'
./run.py
```

then you can do:

```
! hello
$ hello
@botname hello
```

and it'll work.

@lins05 if this direction is something you think would be worthwhile in upstream, I can also add some unit tests here to complete this PR.

inspired by a previous stab at solving this problem by Dan

thanks!
-Dom
