### PR TITLE
Send tracebacks to a specified channel/group/user

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ default_reply = "Sorry but I didn't understood you"
 ##### Configure the docs answer
 The `message` attribute passed to [your custom plugins](#create-plugins) has an special function `message.docs_reply()` that will parse all the plugins available and return the Docs in each of them.
 
+##### Send all tracebacks directly to a channel, group, or user
+Set `ERRORS_TO` in `slackbot_settings.py` to the desired recipient. It can be any channel, group, or user. Note that the bot must already be in the channel. If a user is specified, ensure that they have sent at least one DM to the bot first.
+
+```python
+ERRORS_TO = 'some_channel'
+# or...
+ERRORS_TO = 'username'
+```
+
 ##### Configure the plugins
 Add [your plugin modules](#create-plugins) to a `PLUGINS` list in `slackbot_settings.py`:
 

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -19,11 +19,14 @@ class Bot(object):
     def __init__(self):
         self._client = SlackClient(
             settings.API_TOKEN,
-            bot_icon=settings.BOT_ICON if hasattr(settings, 'BOT_ICON') else None,
-            bot_emoji=settings.BOT_EMOJI if hasattr(settings, 'BOT_EMOJI') else None
+            bot_icon=settings.BOT_ICON if hasattr(settings,
+                                                  'BOT_ICON') else None,
+            bot_emoji=settings.BOT_EMOJI if hasattr(settings,
+                                                    'BOT_EMOJI') else None
         )
         self._plugins = PluginsManager()
-        self._dispatcher = MessageDispatcher(self._client, self._plugins)
+        self._dispatcher = MessageDispatcher(self._client, self._plugins,
+                                             settings.ERRORS_TO)
 
     def run(self):
         self._plugins.init_plugins()
@@ -42,15 +45,21 @@ class Bot(object):
 
 def respond_to(matchstr, flags=0):
     def wrapper(func):
-        PluginsManager.commands['respond_to'][re.compile(matchstr, flags)] = func
-        logger.info('registered respond_to plugin "%s" to "%s"', func.__name__, matchstr)
+        PluginsManager.commands['respond_to'][
+            re.compile(matchstr, flags)] = func
+        logger.info('registered respond_to plugin "%s" to "%s"', func.__name__,
+                    matchstr)
         return func
+
     return wrapper
 
 
 def listen_to(matchstr, flags=0):
     def wrapper(func):
-        PluginsManager.commands['listen_to'][re.compile(matchstr, flags)] = func
-        logger.info('registered listen_to plugin "%s" to "%s"', func.__name__, matchstr)
+        PluginsManager.commands['listen_to'][
+            re.compile(matchstr, flags)] = func
+        logger.info('registered listen_to plugin "%s" to "%s"', func.__name__,
+                    matchstr)
         return func
+
     return wrapper

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -16,10 +16,17 @@ logger = logging.getLogger(__name__)
 
 
 class MessageDispatcher(object):
-    def __init__(self, slackclient, plugins):
+    def __init__(self, slackclient, plugins, errors_to):
         self._client = slackclient
         self._pool = WorkerPool(self.dispatch_msg)
         self._plugins = plugins
+        self._errors_to = None
+        if errors_to:
+            self._errors_to = self._client.find_channel_by_name(errors_to)
+            if not self._errors_to:
+                raise ValueError(
+                    'Could not find errors_to recipient {!r}'.format(
+                        errors_to))
 
         alias_regex = ''
         if getattr(settings, 'ALIASES', None):
@@ -42,10 +49,21 @@ class MessageDispatcher(object):
                 try:
                     func(Message(self._client, msg), *args)
                 except:
-                    logger.exception('failed to handle message %s with plugin "%s"', text, func.__name__)
-                    reply = u'[{}] I have problem when handling "{}"\n'.format(func.__name__, text)
-                    reply += u'```\n{}\n```'.format(traceback.format_exc())
-                    self._client.rtm_send_message(msg['channel'], reply)
+                    logger.exception(
+                        'failed to handle message %s with plugin "%s"',
+                        text, func.__name__)
+                    reply = u'[{}] I had a problem handling "{}"\n'.format(
+                        func.__name__, text)
+                    tb = u'```\n{}\n```'.format(traceback.format_exc())
+                    if self._errors_to:
+                        self._client.rtm_send_message(msg['channel'], reply)
+                        self._client.rtm_send_message(self._errors_to,
+                                                      '{}\n{}'.format(reply,
+                                                                      tb))
+                    else:
+                        self._client.rtm_send_message(msg['channel'],
+                                                      '{}\n{}'.format(reply,
+                                                                      tb))
 
         if not responded and category == u'respond_to':
             self._default_reply(msg)
@@ -127,26 +145,33 @@ class MessageDispatcher(object):
             from slackbot_settings import default_reply
         except ImportError:
             default_reply = [
-                u'Bad command "{}", You can ask me one of the following questions:\n'.format(msg['text']),
+                u'Bad command "{}", You can ask me one of the following '
+                u'questions:\n'.format(
+                    msg['text']),
             ]
-            default_reply += [u'    • `{0}` {1}'.format(p.pattern, v.__doc__ or "")
-                              for p, v in six.iteritems(self._plugins.commands['respond_to'])]
+            default_reply += [
+                u'    • `{0}` {1}'.format(p.pattern, v.__doc__ or "")
+                for p, v in
+                six.iteritems(self._plugins.commands['respond_to'])]
             # pylint: disable=redefined-variable-type
             default_reply = u'\n'.join(default_reply)
 
         m = Message(self._client, msg)
         m.reply(default_reply)
 
+
 def unicode_compact(func):
     """
     Make sure the first parameter of the decorated method to be a unicode
     object.
     """
+
     @wraps(func)
     def wrapped(self, text, *a, **kw):
         if not isinstance(text, six.text_type):
             text = text.decode('utf-8')
         return func(self, text, *a, **kw)
+
     return wrapped
 
 
@@ -239,5 +264,6 @@ class Message(object):
 
     def docs_reply(self):
         reply = [u'    • `{0}` {1}'.format(v.__name__, v.__doc__ or '')
-                 for _, v in six.iteritems(self._plugins.commands['respond_to'])]
+                 for _, v in
+                 six.iteritems(self._plugins.commands['respond_to'])]
         return u'\n'.join(reply)

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -8,6 +8,8 @@ PLUGINS = [
     'slackbot.plugins',
 ]
 
+ERRORS_TO = None
+
 # API_TOKEN = '###token###'
 
 '''

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -124,6 +124,15 @@ class SlackClient(object):
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])
 
+    def find_channel_by_name(self, channel_name):
+        for channel_id, channel in iteritems(self.channels):
+            try:
+                name = channel['name']
+            except KeyError:
+                name = self.users[channel['user']]['name']
+            if name == channel_name:
+                return channel_id
+
     def find_user_by_name(self, username):
         for userid, user in iteritems(self.users):
             if user['name'] == username:

--- a/tests/unit/slackclient_data.py
+++ b/tests/unit/slackclient_data.py
@@ -1,0 +1,133 @@
+USERS = {
+    u'U0X642GBF': {
+        u'status': None, u'profile': {
+            u'fields': None, u'api_app_id': u'',
+            u'image_1024':
+                u'https://avatars.slack-edge.com/2016-04-01'
+                u'/31208087621_5cdcc86ea7191a220468_512.png',
+            u'real_name': u'',
+            u'image_24':
+                u'https://avatars.slack-edge.com/2016-04-01'
+                u'/31208087621_5cdcc86ea7191a220468_24.png',
+            u'image_original':
+                u'https://avatars.slack-edge.com/2016-04-01'
+                u'/31208087621_5cdcc86ea7191a220468_original.png',
+            u'real_name_normalized': u'',
+            u'image_512':
+                u'https://avatars.slack-edge.com/2016-04-01'
+                u'/31208087621_5cdcc86ea7191a220468_512.png',
+            u'image_32':
+                u'https://avatars.slack-edge.com/2016-04-01'
+                u'/31208087621_5cdcc86ea7191a220468_32.png',
+            u'image_48':
+                u'https://avatars.slack-edge.com/2016-04-01'
+                u'/31208087621_5cdcc86ea7191a220468_48.png',
+            u'image_72':
+                u'https://avatars.slack-edge.com/2016-04-01'
+                u'/31208087621_5cdcc86ea7191a220468_72.png',
+            u'avatar_hash': u'5cdcc86ea719',
+            u'image_192':
+                u'https://avatars.slack-edge.com/2016-04-01'
+                u'/31208087621_5cdcc86ea7191a220468_192.png',
+            u'bot_id': u'B0X5WKZGW'
+        }, u'tz': None, u'name': u'testbot', u'presence': u'away',
+        u'deleted': False, u'is_bot': True,
+        u'tz_label': u'Pacific Daylight Time', u'real_name': u'',
+        u'color': u'e7392d', u'team_id': u'T0X1LOL22', u'is_admin': False,
+        u'is_ultra_restricted': False, u'is_restricted': False,
+        u'is_owner': False, u'tz_offset': -25200, u'id': u'U0X642GBF',
+        u'is_primary_owner': False
+    }, u'U0X4QA7R7': {
+        u'status': None, u'profile': {
+            u'first_name': u'First', u'last_name': u'Last',
+            u'fields': None, u'real_name': u'First Last',
+            u'image_24':
+                u'https://secure.gravatar.com/avatar/12345.jpg',
+            u'real_name_normalized': u'First Last',
+            u'image_512':
+                u'https://secure.gravatar.com/avatar/12345.png',
+            u'image_32':
+                u'https://secure.gravatar.com/avatar/12345.png',
+            u'image_48':
+                u'https://secure.gravatar.com/avatar/12345.png',
+            u'image_72':
+                u'https://secure.gravatar.com/avatar/12345.png',
+            u'avatar_hash': u'hw9avn3s9df',
+            u'email': u'first.last@example.com',
+            u'image_192':
+                u'https://secure.gravatar.com/avatar/12345.png'
+        }, u'tz': u'America/Los_Angeles', u'name': u'user',
+        u'presence': u'active', u'deleted': False, u'is_bot': False,
+        u'tz_label': u'Pacific Daylight Time',
+        u'real_name': u'First Last', u'color': u'9f69e7',
+        u'team_id': u'T0X1LOL22', u'is_admin': True,
+        u'is_ultra_restricted': False, u'is_restricted': False,
+        u'is_owner': True, u'tz_offset': -25200, u'id': u'U0X4QA7R7',
+        u'is_primary_owner': True
+    }, u'USLACKBOT': {
+        u'status': None, u'profile': {
+            u'first_name': u'slackbot', u'last_name': u'', u'fields': None,
+            u'real_name': u'slackbot',
+            u'image_24': u'https://a.slack-edge.com/0180/img/slackbot_24.png',
+            u'real_name_normalized': u'slackbot',
+            u'image_512': u'https://a.slack-edge.com/7fa9/img/slackbot_512'
+                          u'.png',
+            u'image_32': u'https://a.slack-edge.com/2fac/plugins/slackbot'
+                         u'/assets/service_32.png',
+            u'image_48': u'https://a.slack-edge.com/2fac/plugins/slackbot'
+                         u'/assets/service_48.png',
+            u'avatar_hash': u'sv1444671949',
+            u'image_72': u'https://a.slack-edge.com/0180/img/slackbot_72.png',
+            u'email': None,
+            u'image_192': u'https://a.slack-edge.com/66f9/img/slackbot_192.png'
+        }, u'tz': None, u'name': u'slackbot', u'presence': u'active',
+        u'deleted': False, u'is_bot': False,
+        u'tz_label': u'Pacific Daylight Time', u'real_name': u'slackbot',
+        u'color': u'757575', u'team_id': u'T0X1LOL22', u'is_admin': False,
+        u'is_ultra_restricted': False, u'is_restricted': False,
+        u'is_owner': False, u'tz_offset': -25200, u'id': u'USLACKBOT',
+        u'is_primary_owner': False
+    }
+}
+
+CHANNELS = {
+    u'D0X6385P1': {
+        u'last_read': u'0000000000.000000', u'created': 1459497074,
+        u'unread_count': 1, u'is_open': True, u'user': u'USLACKBOT',
+        u'unread_count_display': 1, u'latest': {
+            u'text': u'message from slackbot',
+            u'type': u'message', u'user': u'USLACKBOT',
+            u'ts': u'1459502580.797060'
+        }, u'is_im': True, u'id': u'D0X6385P1', u'has_pins': False
+    }, u'C0X4HEKPA': {
+        u'is_general': False, u'name': u'random', u'is_channel': True,
+        u'created': 1459474652, u'is_member': False, u'is_archived': False,
+        u'creator': u'U0X4QA7R7', u'id': u'C0X4HEKPA', u'has_pins': False
+    }, u'G0X62KL92': {
+        u'topic': {u'last_set': 0, u'value': u'', u'creator': u''},
+        u'name': u'testbot-test', u'last_read': u'1459498753.000002',
+        u'creator': u'U0X4QA7R7', u'is_mpim': False, u'is_archived': False,
+        u'created': 1459498753, u'is_group': True,
+        u'members': [u'U0X4QA7R7', u'U0X642GBF', u'U0X6YHC02'],
+        u'unread_count': 98, u'is_open': True,
+        u'purpose': {u'last_set': 0, u'value': u'', u'creator': u''},
+        u'unread_count_display': 46, u'latest': {
+            u'text': u'testbot: help', u'type': u'message',
+            u'user': u'U0X4QA7R7', u'ts': u'1459642144.000004'
+        }, u'id': u'G0X62KL92', u'has_pins': False
+    }, u'D0X6EF55G': {
+        u'last_read': u'0000000000.000000', u'created': 1459497074,
+        u'unread_count': 594, u'is_open': True, u'user': u'U0X4QA7R7',
+        u'unread_count_display': 248, u'latest': {
+            u'text': u'Bad command '
+                     u'"\u4f60\u4e0d\u660e\u767d\uff0c\u5bf9\u5417\uff1f'
+                     u'", You can ask me one of the following '
+                     u'questions:\n\n    \u2022 `\u4f60\u597d` \n    '
+                     u'\u2022 `hello$` \n    \u2022 `hello_formatting` '
+                     u'\n    \u2022 `upload \\&lt;?(.*)\\&gt;?` \n    '
+                     u'\u2022 `hello_decorators` ',
+            u'type': u'message', u'user': u'U0X642GBF',
+            u'ts': u'1459620329.000350'
+        }, u'is_im': True, u'id': u'D0X6EF55G', u'has_pins': False
+    }
+}

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -1,9 +1,43 @@
 import pytest
 
+import slackbot.dispatcher
+
+
 TEST_ALIASES = ['!', '$', 'botbro']
 FAKE_BOT_ID = 'US99999'
 FAKE_BOT_ATNAME = '<@' + FAKE_BOT_ID + '>'
 FAKE_BOT_NAME = 'fakebot'
+FAKE_CHANNEL = 'C12942JF92'
+
+
+class FakePluginManager:
+    def raising(self, message):
+        raise RuntimeError
+
+    def okay(self, message):
+        message.reply('okay')
+
+    def get_plugins(self, category, message):
+        return [[getattr(self, message), []]]
+
+
+class FakeClient:
+    def __init__(self):
+        self.rtm_messages = []
+
+    def rtm_send_message(self, channel, message, attachments=None):
+        self.rtm_messages.append((channel, message))
+
+
+class FakeMessage:
+    def __init__(self, client, msg):
+        self._client = client
+        self._msg = msg
+
+    def reply(self, message):
+        # Perhaps a bit unnecessary to do it this way, but it's close to how
+        # dispatcher and message actually works
+        self._client.rtm_send_message(self._msg['channel'], message)
 
 
 @pytest.fixture()
@@ -13,13 +47,14 @@ def setup_aliases(monkeypatch):
 
 @pytest.fixture()
 def dispatcher(monkeypatch):
-    from slackbot.dispatcher import MessageDispatcher
-
     def return_fake_bot_id():
         return FAKE_BOT_ID
-    dispatcher = MessageDispatcher(None, None, None)
+
+    dispatcher = slackbot.dispatcher.MessageDispatcher(None, None, None)
     monkeypatch.setattr(dispatcher, '_get_bot_id', return_fake_bot_id)
     monkeypatch.setattr(dispatcher, '_get_bot_name', lambda: FAKE_BOT_NAME)
+    dispatcher._client = FakeClient()
+    dispatcher._plugins = FakePluginManager()
     return dispatcher
 
 
@@ -115,3 +150,33 @@ def test_direct_message_with_name(dispatcher):
 
     msg = dispatcher.filter_text(msg)
     assert msg['text'] == 'hello'
+
+
+def test_dispatch_msg(dispatcher, monkeypatch):
+    monkeypatch.setattr('slackbot.dispatcher.Message', FakeMessage)
+    dispatcher.dispatch_msg(
+        ['reply_to', {'text': 'okay', 'channel': FAKE_CHANNEL}])
+    assert dispatcher._client.rtm_messages == [(FAKE_CHANNEL, 'okay')]
+
+
+def test_dispatch_msg_exception(dispatcher, monkeypatch):
+    monkeypatch.setattr('slackbot.dispatcher.Message', FakeMessage)
+    dispatcher.dispatch_msg(
+        ['reply_to', {'text': 'raising', 'channel': FAKE_CHANNEL}])
+    assert len(dispatcher._client.rtm_messages) == 1
+    error = dispatcher._client.rtm_messages[0]
+    assert error[0] == FAKE_CHANNEL
+    assert 'RuntimeError' in error[1]
+
+
+def test_dispatch_msg_errors_to(dispatcher, monkeypatch):
+    monkeypatch.setattr('slackbot.dispatcher.Message', FakeMessage)
+    dispatcher._errors_to = 'D12345'
+    dispatcher.dispatch_msg(
+        ['reply_to', {'text': 'raising', 'channel': FAKE_CHANNEL}])
+    assert len(dispatcher._client.rtm_messages) == 2
+    user_error = dispatcher._client.rtm_messages[0]
+    assert user_error[0] == FAKE_CHANNEL
+    error = dispatcher._client.rtm_messages[1]
+    assert error[0] == 'D12345'
+    assert 'RuntimeError' in error[1]

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -17,7 +17,7 @@ def dispatcher(monkeypatch):
 
     def return_fake_bot_id():
         return FAKE_BOT_ID
-    dispatcher = MessageDispatcher(None, None)
+    dispatcher = MessageDispatcher(None, None, None)
     monkeypatch.setattr(dispatcher, '_get_bot_id', return_fake_bot_id)
     monkeypatch.setattr(dispatcher, '_get_bot_name', lambda: FAKE_BOT_NAME)
     return dispatcher

--- a/tests/unit/test_slackclient.py
+++ b/tests/unit/test_slackclient.py
@@ -1,0 +1,24 @@
+import pytest
+
+from slackbot.slackclient import SlackClient
+from . import slackclient_data
+
+
+@pytest.fixture
+def slack_client():
+    c = SlackClient(None, connect=False)
+    c.channels = slackclient_data.CHANNELS
+    c.users = slackclient_data.USERS
+    return c
+
+
+def test_find_channel_by_name(slack_client):
+    assert slack_client.find_channel_by_name('slackbot') == 'D0X6385P1'
+    assert slack_client.find_channel_by_name('user') == 'D0X6EF55G'
+    assert slack_client.find_channel_by_name('random') == 'C0X4HEKPA'
+    assert slack_client.find_channel_by_name('testbot-test') == 'G0X62KL92'
+
+
+def test_find_user_by_name(slack_client):
+    assert slack_client.find_user_by_name('user') == 'U0X4QA7R7'
+    assert slack_client.find_user_by_name('slackbot') == 'USLACKBOT'


### PR DESCRIPTION
Adds new config option: ERRORS_TO, and a client helper function for finding
channels/groups.
Fixes #46
