### PR TITLE
Import correct slackbot_settings.py during tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.4.0
 websocket-client>=0.22.0
 slacker>=0.5.5
 six>=1.10.0
+pytest>=2.9.1

--- a/tests/functional/run.py
+++ b/tests/functional/run.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import sys
+import logging
+import logging.config
+
+from slackbot import settings
+from slackbot.bot import Bot
+
+
+def main():
+    kw = {
+        'format': '[%(asctime)s] %(message)s',
+        'datefmt': '%m/%d/%Y %H:%M:%S',
+        'level': logging.DEBUG if settings.DEBUG else logging.INFO,
+        'stream': sys.stdout,
+    }
+    logging.basicConfig(**kw)
+    logging.getLogger('requests.packages.urllib3.connectionpool').setLevel(logging.WARNING)
+    bot = Bot()
+    bot.run()
+
+if __name__ == '__main__':
+    main()

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -26,14 +26,15 @@ def start_proxy():
 def _start_bot_process():
     args = [
         'python',
-        'run.py',
+        'tests/functional/run.py',
     ]
     if TRAVIS:
         args = ['slackbot-test-ctl', 'run'] + args
     env = dict(os.environ)
     env['SLACKBOT_API_TOKEN'] = testbot_apitoken
     env['SLACKBOT_TEST'] = 'true'
-    env['PYTHONPATH'] = ':'.join([dirname(abspath(__file__)), env.get('PYTHONPATH', '')])
+    env['PYTHONPATH'] = ':'.join(
+        [join(dirname(abspath(__file__))), '../..', env.get('PYTHONPATH', '')])
     return subprocess.Popen(args, env=env)
 
 @pytest.yield_fixture(scope='module') # pylint: disable=E1101

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.fixture(scope='function', autouse=True)
+def mock_settings(monkeypatch):
+    class Settings:
+        ALIASES = ''
+
+        def __getattr__(self, item):
+            return None
+
+    settings = Settings()
+    monkeypatch.setattr('slackbot.settings', settings)
+    monkeypatch.setattr('slackbot.dispatcher.settings', settings)


### PR DESCRIPTION
If a slackbot_settings.py is in the same dir as run.py, it
was imported during tests rather than the one in the functional
dir. This change looks for the test environment variable and updates
sys.path to ensure that the test settings file is imported first
rather than any locally defined settings file.
