### PR TITLE
Changes to valid bot mentions

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -26,7 +26,7 @@ class MessageDispatcher(object):
             logger.info('using aliases %s', settings.ALIASES)
             alias_regex = '|(?P<alias>{})'.format('|'.join([re.escape(s) for s in settings.ALIASES.split(',')]))
 
-        self.AT_MESSAGE_MATCHER = re.compile(r'^(?:\<@(?P<atuser>\w+)\>{}):? ?(?P<text>.*)$'.format(alias_regex))
+        self.AT_MESSAGE_MATCHER = re.compile(r'^(?:\<@(?P<atuser>\w+)\>:?{}) ?(?P<text>.*)$'.format(alias_regex))
 
     def start(self):
         self._pool.start()

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -26,7 +26,7 @@ class MessageDispatcher(object):
             logger.info('using aliases %s', settings.ALIASES)
             alias_regex = '|(?P<alias>{})'.format('|'.join([re.escape(s) for s in settings.ALIASES.split(',')]))
 
-        self.AT_MESSAGE_MATCHER = re.compile(r'^(?:\<@(?P<atuser>\w+)\>{}):? (?P<text>.*)$'.format(alias_regex))
+        self.AT_MESSAGE_MATCHER = re.compile(r'^(?:\<@(?P<atuser>\w+)\>{}):? ?(?P<text>.*)$'.format(alias_regex))
 
     def start(self):
         self._pool.start()

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -26,7 +26,7 @@ class MessageDispatcher(object):
             logger.info('using aliases %s', settings.ALIASES)
             alias_regex = '|(?P<alias>{})'.format('|'.join([re.escape(s) for s in settings.ALIASES.split(',')]))
 
-        self.AT_MESSAGE_MATCHER = re.compile(r'^(?:\<@(?P<atuser>\w+)\>:?{}) ?(?P<text>.*)$'.format(alias_regex))
+        self.AT_MESSAGE_MATCHER = re.compile(r'^(?:\<@(?P<atuser>\w+)\>:?|(?P<username>\w+):{}) ?(?P<text>.*)$'.format(alias_regex))
 
     def start(self):
         self._pool.start()
@@ -78,10 +78,14 @@ class MessageDispatcher(object):
     def _get_bot_id(self):
         return self._client.login_data['self']['id']
 
+    def _get_bot_name(self):
+        return self._client.login_data['self']['name']
+
     def filter_text(self, msg):
         full_text = msg.get('text', '')
         channel = msg['channel']
-        bot_name = self._get_bot_id()
+        bot_name = self._get_bot_name()
+        bot_id = self._get_bot_id()
         m = self.AT_MESSAGE_MATCHER.match(full_text)
 
         if channel[0] == 'C' or channel[0] == 'G':
@@ -90,14 +94,15 @@ class MessageDispatcher(object):
 
             matches = m.groupdict()
 
-            atuser = matches.get('atuser', None)
-            text = matches.get('text', None)
-            alias = matches.get('alias', None)
+            atuser = matches.get('atuser')
+            username = matches.get('username')
+            text = matches.get('text')
+            alias = matches.get('alias')
 
             if alias:
-                atuser = bot_name
+                atuser = bot_id
 
-            if atuser != bot_name:
+            if atuser != bot_id and username != bot_name:
                 # a channel message at other user
                 return
 

--- a/tests/functional/driver.py
+++ b/tests/functional/driver.py
@@ -54,27 +54,29 @@ class Driver(object):
         else:
             raise AssertionError('test bot is still {}'.format('offline' if online else 'online'))
 
-    def _format_message(self, msg, tobot=True, colon=True, space=True):
+    def _format_message(self, msg, tobot=True, toname=False, colon=True,
+                        space=True):
         colon = ':' if colon else ''
         space = ' ' if space else ''
         if tobot:
             msg = u'<@{}>{}{}{}'.format(self.testbot_userid, colon, space, msg)
+        elif toname:
+            msg = u'{}{}{}{}'.format(self.testbot_username, colon, space, msg)
         return msg
 
     def send_direct_message(self, msg, tobot=False, colon=True):
         msg = self._format_message(msg, tobot, colon)
         self._send_message_to_bot(self.dm_chan, msg)
 
-    def _send_channel_message(self, chan, msg, tobot=True, colon=True,
-                              space=True):
-        msg = self._format_message(msg, tobot, colon, space)
+    def _send_channel_message(self, chan, msg, **kwargs):
+        msg = self._format_message(msg, **kwargs)
         self._send_message_to_bot(chan, msg)
 
-    def send_channel_message(self, msg, tobot=True, colon=True, space=True):
-        self._send_channel_message(self.cm_chan, msg, tobot, colon, space)
+    def send_channel_message(self, msg, **kwargs):
+        self._send_channel_message(self.cm_chan, msg, **kwargs)
 
-    def send_group_message(self, msg, tobot=True, colon=True):
-        self._send_channel_message(self.gm_chan, msg, tobot, colon)
+    def send_group_message(self, msg, **kwargs):
+        self._send_channel_message(self.gm_chan, msg, **kwargs)
 
     def wait_for_bot_direct_message(self, match):
         self._wait_for_bot_message(self.dm_chan, match, tosender=False)
@@ -86,8 +88,8 @@ class Driver(object):
     def wait_for_bot_channel_message(self, match, tosender=True):
         self._wait_for_bot_message(self.cm_chan, match, tosender=tosender)
 
-    def wait_for_bot_group_message(self, match):
-        self._wait_for_bot_message(self.gm_chan, match, tosender=True)
+    def wait_for_bot_group_message(self, match, tosender=True):
+        self._wait_for_bot_message(self.gm_chan, match, tosender=tosender)
 
     def ensure_only_specificmessage_from_bot(self, match, wait=5, tosender=False):
         if tosender is True:

--- a/tests/functional/driver.py
+++ b/tests/functional/driver.py
@@ -129,6 +129,7 @@ class Driver(object):
             raise AssertionError('expected to get reaction "{}", but got nothing'.format(emojiname))
 
     def _send_message_to_bot(self, channel, msg):
+        self.clear_events()
         self._start_ts = time.time()
         self.slacker.chat.post_message(channel, msg, username=self.driver_username)
 

--- a/tests/functional/driver.py
+++ b/tests/functional/driver.py
@@ -54,22 +54,24 @@ class Driver(object):
         else:
             raise AssertionError('test bot is still {}'.format('offline' if online else 'online'))
 
-    def _format_message(self, msg, tobot=True, colon=True):
+    def _format_message(self, msg, tobot=True, colon=True, space=True):
         colon = ':' if colon else ''
+        space = ' ' if space else ''
         if tobot:
-            msg = u'<@{}>{} {}'.format(self.testbot_userid, colon, msg)
+            msg = u'<@{}>{}{}{}'.format(self.testbot_userid, colon, space, msg)
         return msg
 
     def send_direct_message(self, msg, tobot=False, colon=True):
         msg = self._format_message(msg, tobot, colon)
         self._send_message_to_bot(self.dm_chan, msg)
 
-    def _send_channel_message(self, chan, msg, tobot=True, colon=True):
-        msg = self._format_message(msg, tobot, colon)
+    def _send_channel_message(self, chan, msg, tobot=True, colon=True,
+                              space=True):
+        msg = self._format_message(msg, tobot, colon, space)
         self._send_message_to_bot(chan, msg)
 
-    def send_channel_message(self, msg, tobot=True, colon=True):
-        self._send_channel_message(self.cm_chan, msg, tobot, colon)
+    def send_channel_message(self, msg, tobot=True, colon=True, space=True):
+        self._send_channel_message(self.cm_chan, msg, tobot, colon, space)
 
     def send_group_message(self, msg, tobot=True, colon=True):
         self._send_channel_message(self.gm_chan, msg, tobot, colon)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -105,6 +105,28 @@ def test_bot_reply_to_channel_message(driver):
     driver.send_channel_message('hello', colon=False, space=False)
     driver.wait_for_bot_channel_message('hello sender!')
 
+def test_bot_channel_reply_to_name_colon(driver):
+    driver.send_channel_message('hello', tobot=False, toname=True)
+    driver.wait_for_bot_channel_message('hello sender!')
+    driver.send_channel_message('hello', tobot=False, toname=True, space=False)
+    driver.wait_for_bot_channel_message('hello sender!')
+    driver.send_channel_message('hello', tobot=False, toname=True, colon=False)
+    driver.wait_for_bot_channel_message('hello channel!', tosender=False)
+    driver.send_channel_message('hello', tobot=False, toname=True, colon=False,
+                                space=False)
+    driver.wait_for_bot_channel_message('hello channel!', tosender=False)
+
+def test_bot_group_reply_to_name_colon(driver):
+    driver.send_group_message('hello', tobot=False, toname=True)
+    driver.wait_for_bot_group_message('hello sender!')
+    driver.send_group_message('hello', tobot=False, toname=True, space=False)
+    driver.wait_for_bot_group_message('hello sender!')
+    driver.send_group_message('hello', tobot=False, toname=True, colon=False)
+    driver.wait_for_bot_group_message('hello channel!', tosender=False)
+    driver.send_group_message('hello', tobot=False, toname=True, colon=False,
+                                space=False)
+    driver.wait_for_bot_group_message('hello channel!', tosender=False)
+
 def test_bot_listen_to_channel_message(driver):
     driver.send_channel_message('hello', tobot=False)
     driver.wait_for_bot_channel_message('hello channel!', tosender=False)
@@ -164,7 +186,7 @@ def test_bot_reply_with_unicode_message(driver):
     driver.wait_for_bot_channel_message(u'.*You can ask me.*')
 
 def test_bot_reply_with_alias_message(driver):
-    driver.send_channel_message("! hello", False, False)
+    driver.send_channel_message("! hello", tobot=False, colon=False)
     driver.wait_for_bot_channel_message("hello sender!", tosender=True)
-    driver.send_channel_message('!hello', False, False)
+    driver.send_channel_message('!hello', tobot=False, colon=False)
     driver.wait_for_bot_channel_message("hello sender!", tosender=True)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -99,6 +99,11 @@ def test_bot_reply_to_channel_message(driver):
     driver.wait_for_bot_channel_message('hello sender!')
     driver.send_channel_message('hello', colon=False)
     driver.wait_for_bot_channel_message('hello sender!')
+    driver.send_channel_message('hello', space=False)
+    driver.wait_for_bot_channel_message('hello sender!')
+    # This is hard for a user to do, but why not test it?
+    driver.send_channel_message('hello', colon=False, space=False)
+    driver.wait_for_bot_channel_message('hello sender!')
 
 def test_bot_listen_to_channel_message(driver):
     driver.send_channel_message('hello', tobot=False)
@@ -160,4 +165,6 @@ def test_bot_reply_with_unicode_message(driver):
 
 def test_bot_reply_with_alias_message(driver):
     driver.send_channel_message("! hello", False, False)
+    driver.wait_for_bot_channel_message("hello sender!", tosender=True)
+    driver.send_channel_message('!hello', False, False)
     driver.wait_for_bot_channel_message("hello sender!", tosender=True)

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -3,6 +3,8 @@ import pytest
 TEST_ALIASES = ['!', '$', 'botbro']
 FAKE_BOT_ID = 'US99999'
 FAKE_BOT_ATNAME = '<@' + FAKE_BOT_ID + '>'
+FAKE_BOT_NAME = 'fakebot'
+
 
 @pytest.fixture()
 def setup_aliases(monkeypatch):
@@ -17,6 +19,7 @@ def dispatcher(monkeypatch):
         return FAKE_BOT_ID
     dispatcher = MessageDispatcher(None, None)
     monkeypatch.setattr(dispatcher, '_get_bot_id', return_fake_bot_id)
+    monkeypatch.setattr(dispatcher, '_get_bot_name', lambda: FAKE_BOT_NAME)
     return dispatcher
 
 
@@ -46,12 +49,25 @@ def test_nondirectmsg_works(dispatcher):
     assert dispatcher.filter_text(msg) is None
 
 
-def test_botname_works(dispatcher):
+def test_bot_atname_works(dispatcher):
     msg = {
         'text': FAKE_BOT_ATNAME + ' hello',
         'channel': 'C99999'
     }
 
+    msg = dispatcher.filter_text(msg)
+    assert msg['text'] == 'hello'
+
+
+def test_bot_name_works(dispatcher):
+    msg = {
+        'channel': 'C99999'
+    }
+
+    msg['text'] = FAKE_BOT_NAME + ': hello'
+    msg = dispatcher.filter_text(msg)
+    assert msg['text'] == 'hello'
+    msg['text'] = FAKE_BOT_NAME + ':hello'
     msg = dispatcher.filter_text(msg)
     assert msg['text'] == 'hello'
 

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -2,7 +2,7 @@ import pytest
 
 TEST_ALIASES = ['!', '$', 'botbro']
 FAKE_BOT_ID = 'US99999'
-FAKE_BOT_NAME = '<@' + FAKE_BOT_ID + '>'
+FAKE_BOT_ATNAME = '<@' + FAKE_BOT_ID + '>'
 
 @pytest.fixture()
 def setup_aliases(monkeypatch):
@@ -29,6 +29,9 @@ def test_aliases(setup_aliases, dispatcher):
         msg['text'] = a + ' hello'
         msg = dispatcher.filter_text(msg)
         assert msg['text'] == 'hello'
+        msg['text'] = a + 'hello'
+        msg = dispatcher.filter_text(msg)
+        assert msg['text'] == 'hello'
 
 
 def test_nondirectmsg_works(dispatcher):
@@ -45,7 +48,7 @@ def test_nondirectmsg_works(dispatcher):
 
 def test_botname_works(dispatcher):
     msg = {
-        'text': FAKE_BOT_NAME + ' hello',
+        'text': FAKE_BOT_ATNAME + ' hello',
         'channel': 'C99999'
     }
 
@@ -55,7 +58,7 @@ def test_botname_works(dispatcher):
 
 def test_botname_works_with_aliases_present(setup_aliases, dispatcher):
     msg = {
-        'text': FAKE_BOT_NAME + ' hello',
+        'text': FAKE_BOT_ATNAME + ' hello',
         'channel': 'G99999'
     }
 
@@ -69,6 +72,10 @@ def test_no_aliases_doesnt_work(dispatcher):
     }
     for a in TEST_ALIASES:
         text = a + ' hello'
+        msg['text'] = text
+        assert dispatcher.filter_text(msg) is None
+        assert msg['text'] == text
+        text = a + 'hello'
         msg['text'] = text
         assert dispatcher.filter_text(msg) is None
         assert msg['text'] == text
@@ -86,7 +93,7 @@ def test_direct_message(dispatcher):
 
 def test_direct_message_with_name(dispatcher):
     msg = {
-        'text': FAKE_BOT_NAME + ' hello',
+        'text': FAKE_BOT_ATNAME + ' hello',
         'channel': 'D99999'
     }
 


### PR DESCRIPTION
This makes changes to the matcher as follows. All examples suppose ALIAS = '!'. Before:
Matches:
@botname text
@botname: text
! text
!: text
Not matches:
@botname:text
!text
botname: text
botname:text
botname text
botnametext

After:
Matches:
@botname: text
@botname:text
! text
!text
botname: text
botname:text

Not matches:
botname text
botnametext
!: text
!:text

This change also fixes a bug in functional tests that sent more than one message. The event queue only got cleared after each test function, so matches from earlier messages would pass a test that should fail.
