### PR TITLE
Make DEFAULT_REPLY work like all other settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ if __name__ == "__main__":
     main()
 ```
 ##### Configure the default answer
-Add to `slackbot_settings.py` a default_reply:
+Add a DEFAULT_REPLY to `slackbot_settings.py`:
 ```python
-default_reply = "Sorry but I didn't understand you"
+DEFAULT_REPLY = "Sorry but I didn't understand you"
 ```
 
 ##### Configure the docs answer

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -141,9 +141,8 @@ class MessageDispatcher(object):
             time.sleep(1)
 
     def _default_reply(self, msg):
-        try:
-            from slackbot_settings import default_reply
-        except ImportError:
+        default_reply = settings.DEFAULT_REPLY
+        if default_reply is None:
             default_reply = [
                 u'Bad command "{}", You can ask me one of the following '
                 u'questions:\n'.format(

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -33,6 +33,9 @@ effect.
 # BOT_ICON = 'http://lorempixel.com/64/64/abstract/7/'
 # BOT_EMOJI = ':godmode:'
 
+'''Specify a different reply when the bot is messaged with no matching cmd'''
+DEFAULT_REPLY = None
+
 for key in os.environ:
     if key[:9] == 'SLACKBOT_':
         name = key[9:]
@@ -45,3 +48,9 @@ except ImportError:
         from local_settings import *
     except ImportError:
         pass
+
+# convert default_reply to DEFAULT_REPLY
+try:
+    DEFAULT_REPLY = default_reply
+except NameError:
+    pass


### PR DESCRIPTION
default_reply was read directly from slackbot_settings. This prevented
setting it with environment variables, using other settings files, and
other ways of changing settings outside of the slackbot_settings import.
This change makes it work like every other setting, and also renames
default_reply to DEFAULT_REPLY to make it match other settings. Because
some users might have a slackbot_settings file with default_reply set,
this change also converts default_reply to DEFAULT_REPLY.
