### PR TITLE
Update send_webapi() to send as_user by default

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -201,7 +201,7 @@ class Message(object):
             return text
 
     @unicode_compact
-    def reply_webapi(self, text):
+    def reply_webapi(self, text, as_user=True):
         """
             Send a reply to the sender using Web API
 
@@ -209,10 +209,10 @@ class Message(object):
             when using a bot integration)
         """
         text = self.gen_reply(text)
-        self.send_webapi(text)
+        self.send_webapi(text, as_user=as_user)
 
     @unicode_compact
-    def send_webapi(self, text, attachments=None):
+    def send_webapi(self, text, attachments=None, as_user=True):
         """
             Send a reply using Web API
 
@@ -222,7 +222,8 @@ class Message(object):
         self._client.send_message(
             self._body['channel'],
             text,
-            attachments=attachments)
+            attachments=attachments,
+            as_user=as_user)
 
     @unicode_compact
     def reply(self, text):

--- a/slackbot/plugins/hello.py
+++ b/slackbot/plugins/hello.py
@@ -9,6 +9,16 @@ def hello_reply(message):
     message.reply('hello sender!')
 
 
+@respond_to('^reply_webapi$')
+def hello_webapi(message):
+    message.reply_webapi('hello there!')
+
+
+@respond_to('^reply_webapi_not_as_user$')
+def hello_webapi_not_as_user(message):
+    message.reply_webapi('hi!', as_user=False)
+
+
 @respond_to('hello_formatting')
 def hello_reply_formatting(message):
     # Format message with italic style

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -23,10 +23,12 @@ will now also respond to
 ALIASES = ''
 
 '''
-If you use Slack Web API to send messages (with send_webapi() or reply_webapi()),
-you can customize the bot logo by providing Icon or Emoji.
-If you use Slack RTM API to send messages (with send() or reply()),
-the used icon comes from bot settings and Icon or Emoji has no effect.
+If you use Slack Web API to send messages (with
+send_webapi(text, as_user=False) or reply_webapi(text, as_user=False)),
+you can customize the bot logo by providing Icon or Emoji. If you use Slack
+RTM API to send messages (with send() or reply()), or if as_user is True
+(default), the used icon comes from bot settings and Icon or Emoji has no
+effect.
 '''
 # BOT_ICON = 'http://lorempixel.com/64/64/abstract/7/'
 # BOT_EMOJI = ':godmode:'

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -112,14 +112,15 @@ class SlackClient(object):
                                  filename=fname,
                                  initial_comment=comment)
 
-    def send_message(self, channel, message, attachments=None):
+    def send_message(self, channel, message, attachments=None, as_user=True):
         self.webapi.chat.post_message(
                 channel,
                 message,
                 username=self.login_data['self']['name'],
                 icon_url=self.bot_icon,
                 icon_emoji=self.bot_emoji,
-                attachments=attachments)
+                attachments=attachments,
+                as_user=as_user)
 
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])


### PR DESCRIPTION
Slackbot has an option to define an icon and emoji for web API sends. Each
send with the web API allows the caller to specify a different icon/emoji.
This strikes me as behavior that probably shouldn't be default. By using the
as_user option, the send keeps the same icon/emoji as the bot integration and
looks identical to messages sent with .reply().
Test results: https://travis-ci.org/jtatum/slackbot/builds/123487173
![screen shot 2016-04-15 at 5 42 28 pm](https://cloud.githubusercontent.com/assets/340001/14578004/e3e91e7a-0331-11e6-81d6-9a2307d3d675.png)
