### PR TITLE
Support attachments in message.reply_webapi()

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -201,7 +201,7 @@ class Message(object):
             return text
 
     @unicode_compact
-    def reply_webapi(self, text, as_user=True):
+    def reply_webapi(self, text, attachments=None, as_user=True):
         """
             Send a reply to the sender using Web API
 
@@ -209,7 +209,7 @@ class Message(object):
             when using a bot integration)
         """
         text = self.gen_reply(text)
-        self.send_webapi(text, as_user=as_user)
+        self.send_webapi(text, attachments=attachments, as_user=as_user)
 
     @unicode_compact
     def send_webapi(self, text, attachments=None, as_user=True):

--- a/slackbot/plugins/hello.py
+++ b/slackbot/plugins/hello.py
@@ -11,7 +11,16 @@ def hello_reply(message):
 
 @respond_to('^reply_webapi$')
 def hello_webapi(message):
-    message.reply_webapi('hello there!')
+    message.reply_webapi('hello there!', attachments=[{
+        'fallback': 'test attachment',
+        'fields': [
+            {
+                'title': 'test table field',
+                'value': 'test table value',
+                'short': True
+            }
+        ]
+    }])
 
 
 @respond_to('^reply_webapi_not_as_user$')


### PR DESCRIPTION
Attachment support worked in send_webapi(), but not reply_webapi().
Tests: https://travis-ci.org/jtatum/slackbot/builds/123576424
