### PR TITLE
added default_reply() as a plugin capability

### DIFF
--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -63,3 +63,14 @@ def listen_to(matchstr, flags=0):
         return func
 
     return wrapper
+
+
+def default_reply(matchstr=r'^.*$', flags=0):
+    def wrapper(func):
+        PluginsManager.commands['default_reply'][
+            re.compile(matchstr, flags)] = func
+        logger.info('registered default_reply plugin "%s" to "%s"', func.__name__,
+                    matchstr)
+        return func
+
+    return wrapper

--- a/slackbot/manager.py
+++ b/slackbot/manager.py
@@ -17,7 +17,8 @@ class PluginsManager(object):
 
     commands = {
         'respond_to': {},
-        'listen_to': {}
+        'listen_to': {},
+        'default_reply': {}
     }
 
     def init_plugins(self):


### PR DESCRIPTION
Added decorator, default_reply(), so that plugins can pick up unhandled messages and respond.

My use case here is that we have been creating a few plugins for our bot and when none of them match, instead of repeating, "Sorry but I didn't understand you" again and again I thought it would be fun to be able to answer more interactively.

![slackbot-eliza-screenshot](https://cloud.githubusercontent.com/assets/50862/15275575/513153bc-1a84-11e6-95d4-93d67fbcb38b.png)

The first experiment is an simple implementation of an [ELIZA](https://github.com/slowbluecamera/slackbot-eliza) chatbot. If a `respond_to` falls through to the end unhandled, then the plugin is given a chance to handle it.  I've added a [new decorator](https://github.com/slowbluecamera/slackbot-eliza/blob/master/slackbot-eliza/slackbot-eliza.py#L250) for plugins to be able to implement the default responses.

Thanks for the complete contribution guidelines. I think I've followed them all. Please let me know if there is anything you'd like changed or reviewed, or really, if there is anything in the PR that costs you time or concern to review.

And thanks for developing & sharing slackbot. It has been very handy, particularly the "plugin as module" design.  We went through a few bot implementations and slackbot had the right balance of simplicity and flexibility for us. I hope this small feature fits in.
