### PR TITLE
Adding capability to run in background and send messages.

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -134,14 +134,13 @@ class MessageDispatcher(object):
                 msg['text'] = m.groupdict().get('text', None)
         return msg
 
-    def loop(self):
-        while True:
-            events = self._client.rtm_read()
-            for event in events:
-                if event.get('type') != 'message':
-                    continue
-                self._on_new_message(event)
-            time.sleep(1)
+    def handle_events(self):
+        events = self._client.rtm_read()
+        for event in events:
+            if event.get('type') != 'message':
+                continue
+            self._on_new_message(event)
+
 
     def _default_reply(self, msg):
         default_reply = settings.DEFAULT_REPLY


### PR DESCRIPTION
With the intent to provide a better interface for doing things like the #42 I made a modification so, if needed, the bot can be executed in background and can be used to send messages still.
Based on that one can do the cron execute after it and just call bot.send_message().

For doing that I moved the loop from the dispatcher to to the bot and created a thread if it was running on background.

If used with default parameters, the behavior remains the same.
