### PR TITLE
No more stack traces to end-users

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ ERRORS_TO = 'some_channel'
 ERRORS_TO = 'username'
 ```
 
+##### Hide tracebacks
+
+If you are running a production environment and don't want your end-users to see tracebacks, add the following in `slackbot_settings.py` :
+
+```python
+HIDE_TRACEBACKS = True
+ERROR_MSG = "I had a problem with that command. Please try again or contact an administrator. "
+```
+
 ##### Configure the plugins
 Add [your plugin modules](#create-plugins) to a `PLUGINS` list in `slackbot_settings.py`:
 


### PR DESCRIPTION
# What

Adds the ability to override error messages so that production end-users do not see stack traces.
# Why

It's embarrassing to show stack traces to end users.
# Img

![exploits_of_a_mom](https://cloud.githubusercontent.com/assets/513929/16288686/d2b58ad0-38ab-11e6-9edd-531c54622f86.png)
