### PR TITLE
Skip group tests if group is not set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ slackbot_test_settings.py
 /dist
 /*.egg-info
 .cache
+.idea
+

--- a/tests/functional/driver.py
+++ b/tests/functional/driver.py
@@ -37,6 +37,8 @@ class Driver(object):
         # self._fetch_users()
         self._start_dm_channel()
         self._join_test_channel()
+        if self.test_group:
+            self._join_test_group()
 
     def wait_for_bot_online(self):
         self._wait_for_bot_presense(True)
@@ -244,6 +246,7 @@ class Driver(object):
         self.cm_chan = response.body['channel']['id']
         self._invite_testbot_to_channel()
 
+    def _join_test_group(self):
         groups = self.slacker.groups.list(self.test_group).body['groups']
         for group in groups:
             if self.test_group == group['name']:

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -53,6 +53,14 @@ def driver():
 def clear_events(driver):
     driver.clear_events()
 
+
+def skip_if_no_test_group(f):
+    """Mark the test as skipped if no test_group is set."""
+    if test_group:
+        return f
+    return pytest.mark.skip(f)
+
+
 def test_bot_get_online(driver): # pylint: disable=W0613
     pass
 
@@ -118,6 +126,8 @@ def test_bot_channel_reply_to_name_colon(driver):
                                 space=False)
     driver.wait_for_bot_channel_message('hello channel!', tosender=False)
 
+
+@skip_if_no_test_group
 def test_bot_group_reply_to_name_colon(driver):
     driver.send_group_message('hello', tobot=False, toname=True)
     driver.wait_for_bot_group_message('hello sender!')
@@ -129,6 +139,7 @@ def test_bot_group_reply_to_name_colon(driver):
                                 space=False)
     driver.wait_for_bot_group_message('hello channel!', tosender=False)
 
+
 def test_bot_listen_to_channel_message(driver):
     driver.send_channel_message('hello', tobot=False)
     driver.wait_for_bot_channel_message('hello channel!', tosender=False)
@@ -137,11 +148,14 @@ def test_bot_react_to_channel_message(driver):
     driver.send_channel_message('hey!', tobot=False)
     driver.ensure_reaction_posted('eggplant')
 
+
+@skip_if_no_test_group
 def test_bot_reply_to_group_message(driver):
     driver.send_group_message('hello')
     driver.wait_for_bot_group_message('hello sender!')
     driver.send_group_message('hello', colon=False)
     driver.wait_for_bot_group_message('hello sender!')
+
 
 def test_bot_ignores_non_related_message_response_tosender(driver):
     driver.send_channel_message('hello', tobot=True)


### PR DESCRIPTION
Slack apparently requires you to pay money now to create a user group. This means creating a new Slack just to test the bot is unwieldy.

I simply made it skip the group tests if the test_group is falsy.
