### PR TITLE
Stop recommending ``sudo pip install``

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A chat bot for [Slack](https://slack.com) inspired by [llimllib/limbo](https://g
 
 
 ```
-sudo pip install slackbot
+pip install slackbot
 ```
 
 ## Usage


### PR DESCRIPTION
Recommending `sudo` without any rationale as to why seems rather rash.

In addition to this change, if you really wanted to cater for Python novices, perhaps you could link to steps for creating a Python virtual environment.
