### PR TITLE
Support comparing channel by name or id

### DIFF
--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -160,6 +160,11 @@ class Channel(object):
         self._body = body
         self._client = slackclient
 
+    def __eq__(self, compare_str):
+        name = self._body['name']
+        cid = self._body['id']
+        return name == compare_str or "#" + name == compare_str or cid == compare_str
+
     def upload_file(self, fname, fpath, initial_comment=''):
         self._client.upload_file(
             self._body['id'],


### PR DESCRIPTION
Thanks for the lovely library. I'm building a permission system for finer-grained access control to the bot, so inevitably, I stumbled upon the need to check whether some messages belong to certain channel. This PR is a direct port of the functionality in the official slackclient's channel object: https://github.com/slackhq/python-slackclient/blob/master/slackclient/_channel.py#L11-L15
