### PR TITLE
added /me message support

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -214,18 +214,20 @@ class Message(object):
         self.send_webapi(text, attachments=attachments, as_user=as_user)
 
     @unicode_compact
-    def send_webapi(self, text, attachments=None, as_user=True):
+    def send_webapi(self, text, attachments=None, as_user=True, me_message=False):
         """
-            Send a reply using Web API
-
-            (This function supports formatted message
-            when using a bot integration)
+            Send message via Web API
         """
-        self._client.send_message(
-            self._body['channel'],
-            text,
-            attachments=attachments,
-            as_user=as_user)
+        if me_message is False:
+            self._client.send_message(
+                self._body['channel'],
+                text,
+                attachments=attachments,
+                as_user=as_user)
+        else:
+            self._client.send_me_message(
+                self._body['channel'],
+                text)
 
     @unicode_compact
     def reply(self, text):

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -135,6 +135,11 @@ class SlackClient(object):
                 attachments=attachments,
                 as_user=as_user)
 
+   def send_me_message(self, channel, message):
+        self.webapi.chat.me_message(
+                channel,
+                message)
+
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])
 


### PR DESCRIPTION
This adds the support for /me messages so the bot can ponder things to itself in a channel.

For instance, this will create a /me message:

```
@listen_to('Are you ready?', re.IGNORECASE)
def ready(message):
    message.send_webapi('thinks he is ready',me_message=True)
```