### PR TITLE
Support messages with new line characters

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -33,7 +33,7 @@ class MessageDispatcher(object):
             logger.info('using aliases %s', settings.ALIASES)
             alias_regex = '|(?P<alias>{})'.format('|'.join([re.escape(s) for s in settings.ALIASES.split(',')]))
 
-        self.AT_MESSAGE_MATCHER = re.compile(r'^(?:\<@(?P<atuser>\w+)\>:?|(?P<username>\w+):{}) ?(?P<text>.*)$'.format(alias_regex))
+        self.AT_MESSAGE_MATCHER = re.compile(r'^(?:\<@(?P<atuser>\w+)\>:?|(?P<username>\w+):{}) ?(?P<text>.*)$'.format(alias_regex),re.DOTALL)
 
     def start(self):
         self._pool.start()


### PR DESCRIPTION
Without this change, the bot would ignore any messages with new line characters.

This is useful in the case where you would want to do something like this:

`@respond_to('(.*)', re.DOTALL)`

to match all text including new lines.

I can't think of a case where this would be undesirable. 