### PR TITLE
Handle full_text=None, "expected string or buffer" crash from other bots' messages

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -103,7 +103,7 @@ class MessageDispatcher(object):
         return self._client.login_data['self']['name']
 
     def filter_text(self, msg):
-        full_text = msg.get('text', '')
+        full_text = msg.get('text', '') or ''
         channel = msg['channel']
         bot_name = self._get_bot_name()
         bot_id = self._get_bot_id()


### PR DESCRIPTION
Other bots' messages may contain `None` for the message text, such as in the example below:

```
{
  'event_ts': '1490370300.598923',
  'username': 'removed',
  'type': 'message',
  'team': 'T...',
  'ts': '1490370300.598923',
  'mrkdwn': True,
  'channel': 'G...',
  'text': None,
  'subtype': 'bot_message',
  'bot_id': 'B...',
  'attachments': [{
    'color': 'ac725e',
    'mrkdwn_in': ['text', 'pretext'],
    'title_link': 'https://www.google.com/calendar/event?eid=NH...',
    'title': 'testing slackbot', 'pretext': 'Event starting in 30 minutes:',
    'fallback': 'testing slackbot: <!date^1490372100^{date_short_pretty} from {time}|Mar 24, 2017 from 10:15 AM> to <!date^1490375700^{time}|11:15 AM GMT-0600>',
    'text': '<!date^1490372100^{date_short_pretty} from {time}|Mar 24, 2017 from 10:15 AM> to <!date^1490375700^{time}|11:15 AM GMT-0600>',
    'id': 1
  }]
}
```

The `text` field being `None` makes `msg.get('text', '')` return `None` instead of an empty string, which subsequently crashes the regex match line. Traceback below:

```
Traceback (most recent call last):
  ...
  File "myscript.py", line 84, in main
    bot.run()
  File "/usr/local/lib/python3.4/dist-packages/slackbot/bot.py", line 37, in run
    self._dispatcher.loop()
  File "/usr/local/lib/python3.4/dist-packages/slackbot/dispatcher.py", line 143, in loop
    self._on_new_message(event)
  File "/usr/local/lib/python3.4/dist-packages/slackbot/dispatcher.py", line 93, in _on_new_message
    msg_respond_to = self.filter_text(msg)
  File "/usr/local/lib/python3.4/dist-packages/slackbot/dispatcher.py", line 110, in filter_text
    m = self.AT_MESSAGE_MATCHER.match(full_text)
TypeError: expected string or buffer
```

This PR just adds another fallback, so `None` gets turned into an empty string to avoid crashing.