### PR TITLE
Fix bot breaking when new users join groups/the team

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -138,12 +138,13 @@ class MessageDispatcher(object):
         while True:
             events = self._client.rtm_read()
             for event in events:
-                if event.get('type') == 'message':
+                event_type = event.get('type')
+                if event_type == 'message':
                     self._on_new_message(event)
-                elif event.get('type') in ['channel_created', 'group_joined', 'im_created']:
+                elif event_type in ['channel_created', 'group_joined', 'im_created']:
                     channel = [event['channel']]
                     self._client.parse_channel_data(channel)
-                elif event.get('type') == 'team_join':
+                elif event_type == 'team_join':
                     user = event['user']
                     self._client.users[user['id']] = user
             time.sleep(1)

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -138,9 +138,14 @@ class MessageDispatcher(object):
         while True:
             events = self._client.rtm_read()
             for event in events:
-                if event.get('type') != 'message':
-                    continue
-                self._on_new_message(event)
+                if event.get('type') == 'message':
+                    self._on_new_message(event)
+                elif event.get('type') in ['channel_created', 'group_joined', 'im_created']:
+                    channel = [event['channel']]
+                    self._client.parse_channel_data(channel)
+                elif event.get('type') == 'team_join':
+                    user = event['user']
+                    self._client.users[user['id']] = user
             time.sleep(1)
 
     def _default_reply(self, msg):


### PR DESCRIPTION
This is a resurrection of #117, which was designed to fix the problems with #115 and #61 

Test coverage should be possible. I'm  not sure exactly what tests you'd want though. This lives within the `MessageDispatcher` classes `loop` function, but it primarily relies on `SlackClient` for actual functionality, so if anything a test for `parse_channel_data` should be done. 