### PR TITLE
If new msg text is None, fallback to empty str

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ slackbot_test_settings.py
 /dist
 /*.egg-info
 .cache
+/.vscode/

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -48,7 +48,7 @@ class MessageDispatcher(object):
 
     def _dispatch_msg_handler(self, category, msg):
         responded = False
-        for func, args in self._plugins.get_plugins(category, msg['text']):
+        for func, args in self._plugins.get_plugins(category, msg.get('text', None)):
             if func:
                 responded = True
                 try:

--- a/slackbot/manager.py
+++ b/slackbot/manager.py
@@ -64,6 +64,8 @@ class PluginsManager(object):
 
     def get_plugins(self, category, text):
         has_matching_plugin = False
+        if text is None:
+            text = ''
         for matcher in self.commands[category]:
             m = matcher.search(text)
             if m:

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -200,3 +200,14 @@ def test_dispatch_default_msg_plugin(dispatcher, monkeypatch):
     dispatcher.dispatch_msg(
         ['respond_to', {'text': 'default_okay', 'channel': FAKE_CHANNEL}])
     assert dispatcher._client.rtm_messages == [(FAKE_CHANNEL, 'default_okay')]
+
+
+def test_none_text(dispatcher):
+    # Test for #138: If new msg text is None, fallback to empty str
+    msg = {
+        'text': None,
+        'channel': 'C99999'
+    }
+    # Should not raise a TypeError
+    msg = dispatcher.filter_text(msg)
+    assert msg is None

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import os
 
@@ -15,3 +16,12 @@ def test_import_plugin_single_module():
     assert 'fake_plugin_module' not in sys.modules
     PluginsManager()._load_plugins('fake_plugin_module')
     assert 'fake_plugin_module' in sys.modules
+
+
+def test_get_plugins_none_text():
+    p = PluginsManager()
+    p.commands['respond_to'][re.compile(r'^dummy regexp$')] = lambda x: x
+    # Calling get_plugins() with `text == None`
+    for func, args in p.get_plugins('respond_to', None):
+        assert func is None
+        assert args is None


### PR DESCRIPTION
Equivalent change to b6ba473eabb6f622d24cca3be19efb013dde8481, but happening in a different place. See description from #138.