### PR TITLE
Add reply in thread functionality

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -209,18 +209,21 @@ class Message(object):
             return text
 
     @unicode_compact
-    def reply_webapi(self, text, attachments=None, as_user=True):
+    def reply_webapi(self, text, attachments=None, as_user=True, in_thread=False):
         """
             Send a reply to the sender using Web API
 
             (This function supports formatted message
             when using a bot integration)
         """
-        text = self.gen_reply(text)
-        self.send_webapi(text, attachments=attachments, as_user=as_user)
+        if in_thread:
+            self.send_webapi(text, attachments=attachments, as_user=as_user, thread_ts=self.thread_ts)
+        else:
+            text = self.gen_reply(text)
+            self.send_webapi(text, attachments=attachments, as_user=as_user)
 
     @unicode_compact
-    def send_webapi(self, text, attachments=None, as_user=True):
+    def send_webapi(self, text, attachments=None, as_user=True, thread_ts=None):
         """
             Send a reply using Web API
 
@@ -231,28 +234,32 @@ class Message(object):
             self._body['channel'],
             text,
             attachments=attachments,
-            as_user=as_user)
+            as_user=as_user,
+            thread_ts=thread_ts)
 
     @unicode_compact
-    def reply(self, text):
+    def reply(self, text, in_thread=False):
         """
             Send a reply to the sender using RTM API
 
             (This function doesn't supports formatted message
             when using a bot integration)
         """
-        text = self.gen_reply(text)
-        self.send(text)
+        if in_thread:
+            self.send(text, thread_ts=self.thread_ts)
+        else:
+            text = self.gen_reply(text)
+            self.send(text)
 
     @unicode_compact
-    def send(self, text):
+    def send(self, text, thread_ts=None):
         """
             Send a reply using RTM API
 
             (This function doesn't supports formatted message
             when using a bot integration)
         """
-        self._client.rtm_send_message(self._body['channel'], text)
+        self._client.rtm_send_message(self._body['channel'], text, thread_ts=thread_ts)
 
     def react(self, emojiname):
         """
@@ -270,6 +277,15 @@ class Message(object):
     @property
     def body(self):
         return self._body
+
+    @property
+    def thread_ts(self):
+        try:
+            thread_ts = self.body['thread_ts']
+        except KeyError:
+            thread_ts = self.body['ts']
+
+        return thread_ts
 
     def docs_reply(self):
         reply = [u'    • `{0}` {1}'.format(v.__name__, v.__doc__ or '')

--- a/slackbot/plugins/hello.py
+++ b/slackbot/plugins/hello.py
@@ -52,3 +52,13 @@ def hey(message):
 @respond_to(u'你好')
 def hello_unicode_message(message):
     message.reply(u'你好!')
+
+
+@listen_to('start a thread')
+def start_thread(message):
+    message.reply('I started a thread', in_thread=True)
+
+
+@listen_to('reply in a thread')
+def reply_thread(message):
+    message.reply('I replied in a thread', in_thread=True)

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -109,12 +109,13 @@ class SlackClient(object):
                 data.append(json.loads(d))
         return data
 
-    def rtm_send_message(self, channel, message, attachments=None):
+    def rtm_send_message(self, channel, message, attachments=None, thread_ts=None):
         message_json = {
             'type': 'message',
             'channel': channel,
             'text': message,
-            'attachments': attachments
+            'attachments': attachments,
+            'thread_ts': thread_ts,
             }
         self.send_to_websocket(message_json)
 
@@ -125,7 +126,7 @@ class SlackClient(object):
                                  filename=fname,
                                  initial_comment=comment)
 
-    def send_message(self, channel, message, attachments=None, as_user=True):
+    def send_message(self, channel, message, attachments=None, as_user=True, thread_ts=None):
         self.webapi.chat.post_message(
                 channel,
                 message,
@@ -133,7 +134,8 @@ class SlackClient(object):
                 icon_url=self.bot_icon,
                 icon_emoji=self.bot_emoji,
                 attachments=attachments,
-                as_user=as_user)
+                as_user=as_user,
+                thread_ts=thread_ts)
 
     def get_channel(self, channel_id):
         return Channel(self, self.channels[channel_id])

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -191,3 +191,13 @@ def test_bot_reply_with_alias_message(driver):
     driver.wait_for_bot_channel_message("hello sender!", tosender=True)
     driver.send_channel_message('!hello', tobot=False, colon=False)
     driver.wait_for_bot_channel_message("hello sender!", tosender=True)
+
+
+def test_bot_reply_thread_in_channel(driver):
+    driver.send_channel_message('start a thread', tobot=False, colon=False)
+    driver.wait_for_bot_channel_thread_message('I started a thread', tosender=False)
+
+
+def test_bot_reply_thread_in_group(driver):
+    driver.send_group_message('start a thread', tobot=False, colon=False)
+    driver.wait_for_bot_group_thread_message('I started a thread', tosender=False)


### PR DESCRIPTION
Adds functionality to reply to a message in a thread. This is done by checking if the message already has the `thread_ts` attribute and including it in the message that's send to the API. If the message has no `thread_ts` attribute, the message's `ts` attribute is send instead so a thread can be started. 