### PR TITLE
Make rmt_connect() calling proper

### DIFF
--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -31,7 +31,9 @@ class Bot(object):
     def run(self):
         self._plugins.init_plugins()
         self._dispatcher.start()
-        self._client.rtm_connect()
+        if not self._client.connected: 
+            self._client.rtm_connect()
+            
         _thread.start_new_thread(self._keepactive, tuple())
         logger.info('connected to slack RTM api')
         self._dispatcher.loop()


### PR DESCRIPTION
SlackClient calls `rtm_connect()` on its instantiation.
That's why the code will cause `429 Error` like #162 