### PR TITLE
Add a user attribute to Message

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -281,6 +281,10 @@ class Message(object):
         return self._body
 
     @property
+    def user(self):
+        return self._client.get_user(self._body['user'])
+
+    @property
     def thread_ts(self):
         try:
             thread_ts = self.body['thread_ts']

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -159,6 +159,9 @@ class SlackClient(object):
             if name == channel_name:
                 return channel_id
 
+    def get_user(self, user_id):
+        return self.users.get(user_id)
+
     def find_user_by_name(self, username):
         for userid, user in iteritems(self.users):
             if user['name'] == username:


### PR DESCRIPTION
Credit goes to #110, but since there has been no activity to fix the PR in more than 6 months I'm submitting a similar PR.

Because of #167, it's hard to tell whether or not my change did anything wrong.
Wasn't sure about writing tests either since there doesn't seem to be tests for `get_channel` which is similar to the new `get_user` in this PR, so I didn't write any.