### PR TITLE
Remove reactions to post message

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,19 @@ import re
 @respond_to('hi', re.IGNORECASE)
 def hi(message):
     message.reply('I can understand hi or HI!')
-    # add reaction with thumb up emoji
+    # react with thumb up emoji
     message.react('+1')
 
-    # remove reaction with thumb up emoji by bot-self
-    #time.sleep(1)
-    message.unreact('+1')
+@respond_to('wave')
+def wave(message):
+    # bot adds reaction of :wave: emoji to message
+    message.react('wave')
+
+   from time import sleep
+   sleep(1)
+
+   # bot removes it's reaction of :wave: emoji on message
+   message.unreact('wave')
 
 @respond_to('I love you')
 def love(message):

--- a/README.md
+++ b/README.md
@@ -121,8 +121,12 @@ import re
 @respond_to('hi', re.IGNORECASE)
 def hi(message):
     message.reply('I can understand hi or HI!')
-    # react with thumb up emoji
+    # add reaction with thumb up emoji
     message.react('+1')
+
+    # remove reaction with thumb up emoji by bot-self
+    #time.sleep(1)
+    message.unreact('+1')
 
 @respond_to('I love you')
 def love(message):

--- a/README_ja.md
+++ b/README_ja.md
@@ -120,8 +120,12 @@ import re
 @respond_to('hi', re.IGNORECASE)
 def hi(message):
     message.reply('I can understand hi or HI!')
-    # react with thumb up emoji
+    # add reaction with thumb up emoji
     message.react('+1')
+
+    # remove reaction with thumb up emoji by bot-self
+    #time.sleep(1)
+    message.unreact('+1')
 
 @respond_to('I love you')
 def love(message):

--- a/README_ja.md
+++ b/README_ja.md
@@ -120,12 +120,20 @@ import re
 @respond_to('hi', re.IGNORECASE)
 def hi(message):
     message.reply('I can understand hi or HI!')
-    # add reaction with thumb up emoji
+    # react with thumb up emoji
     message.react('+1')
 
-    # remove reaction with thumb up emoji by bot-self
-    #time.sleep(1)
-    message.unreact('+1')
+@respond_to('wave')
+def wave(message):
+    # bot adds reaction of :wave: emoji to message
+    message.react('wave')
+
+   from time import sleep
+   sleep(1)
+
+   # bot removes it's reaction of :wave: emoji on message
+   message.unreact('wave')
+
 
 @respond_to('I love you')
 def love(message):

--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -282,6 +282,15 @@ class Message(object):
             channel=self._body['channel'],
             timestamp=self._body['ts'])
 
+    def unreact(self, emojiname):
+        """
+           Un react to a message using the web api
+        """
+        self._client.unreact_to_message(
+            emojiname=emojiname,
+            channel=self._body['channel'],
+            timestamp=self._body['ts'])
+
     @property
     def channel(self):
         return self._client.get_channel(self._body['channel'])

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -173,6 +173,12 @@ class SlackClient(object):
             channel=channel,
             timestamp=timestamp)
 
+    def unreact_to_message(self, emojiname, channel, timestamp):
+        self.webapi.reactions.remove(
+            name=emojiname,
+            channel=channel,
+            timestamp=timestamp)
+
 
 class SlackConnectionError(Exception):
     pass

--- a/tests/functional/driver.py
+++ b/tests/functional/driver.py
@@ -131,10 +131,21 @@ class Driver(object):
         else:
             raise AssertionError('expected to get file "{}", but got nothing'.format(name))
 
-    def ensure_reaction_posted(self, emojiname, maxwait=5):
+    def ensure_reaction_adding_posted(self, emojiname, maxwait=5):
         for _ in range(maxwait):
             time.sleep(1)
             if self._has_reacted(emojiname):
+                break
+        else:
+            raise AssertionError('expected to get reaction "{}", but got nothing'.format(emojiname))
+
+    def ensure_reaction_removing_posted(self, emojiname, maxwait=5):
+        if not self._has_reacted(emojiname):
+            raise RuntimeError('Have you the reaction "{}" fortesting?'.format(emojiname))
+
+        for _ in range(maxwait):
+            time.sleep(1)
+            if not self._has_reacted(emojiname):
                 break
         else:
             raise AssertionError('expected to get reaction "{}", but got nothing'.format(emojiname))

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -159,7 +159,13 @@ def test_bot_listen_to_channel_message(driver):
 
 def test_bot_react_to_channel_message(driver):
     driver.send_channel_message('hey!', tobot=False)
-    driver.ensure_reaction_posted('eggplant')
+    driver.ensure_reaction_adding_posted('eggplant')
+
+
+def test_bot_unreact_to_channel_message(driver):
+    driver.send_channel_message('hey!', tobot=False)
+    driver.ensure_reaction_adding_posted('eggplant')
+    driver.ensure_reaction_removing_posted('eggplant')
 
 
 def test_bot_reply_to_private_channel_message(driver):


### PR DESCRIPTION
This proposal is slackbot can remove reaction itself.

For example, the following cases are assumed:

1. add reaction 👀 (`:eyes:`)
1. exec something few times
1. remove reaction `:eyes:`
1. and add reaction :o: (`:o:`)

  