### PR TITLE
Add timeout setting for Slacker

### DIFF
--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -19,6 +19,8 @@ class Bot(object):
     def __init__(self):
         self._client = SlackClient(
             settings.API_TOKEN,
+            timeout=settings.TIMEOUT if hasattr(settings,
+                                                'TIMEOUT') else None,
             bot_icon=settings.BOT_ICON if hasattr(settings,
                                                   'BOT_ICON') else None,
             bot_emoji=settings.BOT_EMOJI if hasattr(settings,

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -10,6 +10,11 @@ PLUGINS = [
 
 ERRORS_TO = None
 
+'''
+Setup timeout for slacker API requests (e.g. uploading a file).
+'''
+TIMEOUT = 100
+
 # API_TOKEN = '###token###'
 
 '''

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class SlackClient(object):
-    def __init__(self, token, bot_icon=None, bot_emoji=None, connect=True):
+    def __init__(self, token, timeout=None, bot_icon=None, bot_emoji=None, connect=True):
         self.token = token
         self.bot_icon = bot_icon
         self.bot_emoji = bot_emoji
@@ -31,7 +31,10 @@ class SlackClient(object):
         self.users = {}
         self.channels = {}
         self.connected = False
-        self.webapi = slacker.Slacker(self.token)
+        if timeout is None:
+            self.webapi = slacker.Slacker(self.token)
+        else:
+            self.webapi = slacker.Slacker(self.token, timeout=timeout)
 
         if connect:
             self.rtm_connect()

--- a/tests/unit/test_slackclient.py
+++ b/tests/unit/test_slackclient.py
@@ -76,3 +76,12 @@ def test_parse_user_data(slack_client):
     }])
     assert slack_client.find_user_by_name('bob') is None
     assert slack_client.find_user_by_name('bob2') == 'U123456'
+
+
+def test_init_with_timeout():
+    client = SlackClient(None, connect=False)
+    assert client.webapi.api.timeout == 10  # seconds default timeout
+
+    expected_timeout = 42  # seconds
+    client = SlackClient(None, connect=False, timeout=expected_timeout)
+    assert client.webapi.api.timeout == expected_timeout


### PR DESCRIPTION
There are serveral parameters for slacker:
```
slacker.Slacker(token,
                incoming_webhook_url=None,
                timeout=DEFAULT_TIMEOUT,
                http_proxy=None,
                https_proxy=None,
                session=None,
                rate_limit_retries=DEFAULT_RETRIES)
```
However, in the previous code, only token is passed to slacker, and
timeout could not be set. It uses DEFAULT_TIMEOUT in slacker, which
is 10 seconds, not enough for slackbot to upload large file (20MB
video for example).
In this commit, timeout could be set in settings as token. Bot()
would pass it to SlackClient and to Slacker if TIMEOUT exists in
settings.