### PR TITLE
add code to fix the proxy setting

### DIFF
--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -62,7 +62,11 @@ class SlackClient(object):
 
         proxy, proxy_port, no_proxy = None, None, None
         if 'http_proxy' in os.environ:
-            proxy, proxy_port = os.environ['http_proxy'].split(':')
+            proxy, proxy_port = os.environ['http_proxy'].rsplit(':',1)
+        if 'http://' in proxy:
+            proxy = proxy[7:]
+        if '/' in proxy_port:
+            proxy_port = proxy_port[:-1]
         if 'no_proxy' in os.environ:
             no_proxy = os.environ['no_proxy']
 

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -15,6 +15,7 @@ from websocket import (
 )
 
 from slackbot.utils import to_utf8
+from slackbot.utils import get_proxy_setting
 
 logger = logging.getLogger(__name__)
 
@@ -60,16 +61,7 @@ class SlackClient(object):
         self.parse_channel_data(login_data['groups'])
         self.parse_channel_data(login_data['ims'])
 
-        proxy, proxy_port, no_proxy = None, None, None
-        if 'http_proxy' in os.environ:
-            proxy, proxy_port = os.environ['http_proxy'].rsplit(':',1)
-        if 'http://' in proxy:
-            proxy = proxy[7:]
-        if '/' in proxy_port:
-            proxy_port = proxy_port[:-1]
-        if 'no_proxy' in os.environ:
-            no_proxy = os.environ['no_proxy']
-
+        proxy, proxy_port, no_proxy = get_proxy_setting()
         self.websocket = create_connection(self.login_data['url'], http_proxy_host=proxy,
                                            http_proxy_port=proxy_port, http_no_proxy=no_proxy)
 

--- a/slackbot/utils.py
+++ b/slackbot/utils.py
@@ -88,10 +88,10 @@ def get_proxy_setting():
     proxy, proxy_port, no_proxy = None, None, None
     if 'http_proxy' in os.environ:
         proxy, proxy_port = os.environ['http_proxy'].rsplit(':',1)
-    # if 'http://' in proxy:
-    proxy = proxy.replace('http://', '')
-    # if '/' in proxy_port:
-    proxy_port = proxy_port.replace('/','')
+    if 'http://' in proxy:
+        proxy = proxy.replace('http://', '')
+    if '/' in proxy_port:
+        proxy_port = proxy_port.replace('/','')
     if 'no_proxy' in os.environ:
         no_proxy = os.environ['no_proxy']
 

--- a/slackbot/utils.py
+++ b/slackbot/utils.py
@@ -77,3 +77,22 @@ class WorkerPool(object):
         while True:
             msg = self.queue.get()
             self.func(msg)
+
+def get_proxy_setting():
+    """To get a fixed proxy setting
+    "http://USERNAME:PASSWORD@proxy.server.com:1234/"
+              || 
+              \/
+    "USERNAME:PASSWORD@proxy.server.com", "1234"
+    """
+    proxy, proxy_port, no_proxy = None, None, None
+    if 'http_proxy' in os.environ:
+        proxy, proxy_port = os.environ['http_proxy'].rsplit(':',1)
+    # if 'http://' in proxy:
+    proxy = proxy.replace('http://', '')
+    # if '/' in proxy_port:
+    proxy_port = proxy_port.replace('/','')
+    if 'no_proxy' in os.environ:
+        no_proxy = os.environ['no_proxy']
+
+    return (proxy, proxy_port, no_proxy)

--- a/slackbot/utils.py
+++ b/slackbot/utils.py
@@ -88,9 +88,9 @@ def get_proxy_setting():
     proxy, proxy_port, no_proxy = None, None, None
     if 'http_proxy' in os.environ:
         proxy, proxy_port = os.environ['http_proxy'].rsplit(':',1)
-    if 'http://' in proxy:
+    if type(proxy).__name__ == 'str' and 'http://' in proxy:
         proxy = proxy.replace('http://', '')
-    if '/' in proxy_port:
+    if type(proxy_port).__name__ == 'str' and '/' in proxy_port:
         proxy_port = proxy_port.replace('/','')
     if 'no_proxy' in os.environ:
         no_proxy = os.environ['no_proxy']


### PR DESCRIPTION
in a local network which is connected to a proxy server, 
if the `os.environ['http_proxy']` is 'http://proxy.server.address:8080/'
and the code is:
```python
proxy, proxy_port = 'http://proxy.server.address:8080/'.split(':')
```
the error would be appear as:
```
ValueError: too many values to unpack (excepted 2)
```
To fix this bug I prefer to use `rsplit(':, 1')`.
And `proxy` should not be written with 'http://', so I fixed it.
