### PR TITLE
Fix naked except

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -53,7 +53,7 @@ class MessageDispatcher(object):
                 responded = True
                 try:
                     func(Message(self._client, msg), *args)
-                except:
+                except Exception:
                     logger.exception(
                         'failed to handle message %s with plugin "%s"',
                         msg['text'], func.__name__)
@@ -267,7 +267,7 @@ class Message(object):
     def direct_reply(self, text):
         """
             Send a reply via direct message using RTM API
-            
+
         """
         channel_id = self._client.open_dm_channel(self._get_user_id())
         self._client.rtm_send_message(channel_id, text)

--- a/slackbot/manager.py
+++ b/slackbot/manager.py
@@ -58,7 +58,7 @@ class PluginsManager(object):
         for module in module_list:
             try:
                 import_module(module)
-            except:
+            except Exception:
                 # TODO Better exception handling
                 logger.exception('Failed to import %s', module)
 

--- a/tests/functional/driver.py
+++ b/tests/functional/driver.py
@@ -204,7 +204,7 @@ class Driver(object):
         while True:
             try:
                 data += '{0}\n'.format(self._websocket.recv())
-            except:
+            except Exception:
                 return data.rstrip()
 
     def _rtm_read_forever(self):


### PR DESCRIPTION
It's nice not to have catch-all `except`, especially to avoid catching `SystemExit`.

(For context:)
Happened for a case when I tried to auto-restart the bot by relying on systemd to reboot it after exiting cleanly with `sys.exit()`. Alternatively, `os.system(f"kill {os.getpid()}")` works but doesn't feel pythonic.
