### PR TITLE
Fix a code error on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ import json
 
 
 @respond_to('github', re.IGNORECASE)
-def github():
+def github(message):
     attachments = [
     {
         'fallback': 'Fallback text',

--- a/README_ja.md
+++ b/README_ja.md
@@ -92,7 +92,7 @@ import json
 
 
 @respond_to('github', re.IGNORECASE)
-def github():
+def github(message):
     attachments = [
     {
         'fallback': 'Fallback text',


### PR DESCRIPTION
An example on README doesn't work due to the lack of the argument `message`.