### PR TITLE
Add support for `bot_message` events without usernames

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -84,6 +84,8 @@ class MessageDispatcher(object):
         except (KeyError, TypeError):
             if 'username' in msg:
                 username = msg['username']
+            elif 'bot_profile' in msg and 'name' in msg['bot_profile']:
+                username = msg['bot_profile']['name']
             else:
                 return
 


### PR DESCRIPTION
As per https://api.slack.com/events/message/bot_message a `bot_message`
may not always contain a username. Username is only present should the
username be overrided in the event request.

Currently when SlackBot receives a `bot_message` with no overriden username it exits not passing the event forward.

This changes updated the relevant code to pull the username from the `bot_profile`