### PR TITLE
Make it possible to copy and execute the command posted in slack

### DIFF
--- a/slackbot/manager.py
+++ b/slackbot/manager.py
@@ -16,8 +16,6 @@ class PluginsManager(object):
     def __init__(self):
         pass
 
-    _space_pattern = re.compile(r'\s')
-
     commands = {
         'respond_to': {},
         'listen_to': {},
@@ -70,7 +68,7 @@ class PluginsManager(object):
         if text is None:
             text = ''
         text = text.strip()
-        text = self._space_pattern.sub(' ', text)
+        text = re.sub(r'\s', ' ', text)
         for matcher in self.commands[category]:
             m = matcher.search(text)
             if m:

--- a/slackbot/manager.py
+++ b/slackbot/manager.py
@@ -16,6 +16,8 @@ class PluginsManager(object):
     def __init__(self):
         pass
 
+    _space_pattern = re.compile(r'\s')
+
     commands = {
         'respond_to': {},
         'listen_to': {},
@@ -68,7 +70,7 @@ class PluginsManager(object):
         if text is None:
             text = ''
         text = text.strip()
-        text = re.sub(r'\s', ' ', text)
+        text = self._space_pattern.sub(' ', text)
         for matcher in self.commands[category]:
             m = matcher.search(text)
             if m:

--- a/slackbot/manager.py
+++ b/slackbot/manager.py
@@ -66,6 +66,7 @@ class PluginsManager(object):
         has_matching_plugin = False
         if text is None:
             text = ''
+        text = text.strip()
         for matcher in self.commands[category]:
             m = matcher.search(text)
             if m:

--- a/slackbot/manager.py
+++ b/slackbot/manager.py
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 
 class PluginsManager(object):
     def __init__(self):
-        pass
-
-    _space_pattern = re.compile(r'\s')
+        self._space_pattern = re.compile(r'\s')
 
     commands = {
         'respond_to': {},

--- a/slackbot/manager.py
+++ b/slackbot/manager.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import re
 from glob import glob
 from six import PY2
 from importlib import import_module
@@ -67,6 +68,7 @@ class PluginsManager(object):
         if text is None:
             text = ''
         text = text.strip()
+        text = re.sub(r'\s', ' ', text)
         for matcher in self.commands[category]:
             m = matcher.search(text)
             if m:

--- a/slackbot/manager.py
+++ b/slackbot/manager.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 
 class PluginsManager(object):
     def __init__(self):
-        self._space_pattern = re.compile(r'\s')
+        pass
+
+    _space_pattern = re.compile(r'\s')
 
     commands = {
         'respond_to': {},

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -31,7 +31,6 @@ def test_get_plugins_text_starting_with_u00a0():
     p = PluginsManager()
     f = lambda x: x
     p.commands['respond_to'][re.compile(r'^dummy$')] = f
-    # Calling get_plugins() with `text == None`
     for func, args in p.get_plugins('respond_to', '\u00a0dummy'):
         assert func == f
         assert len(args) == 0
@@ -41,7 +40,6 @@ def test_get_plugins_text_with_u00a0():
     p = PluginsManager()
     f = lambda x: x
     p.commands['respond_to'][re.compile(r'^dummy foo$')] = f
-    # Calling get_plugins() with `text == None`
     for func, args in p.get_plugins('respond_to', 'dummy\u00a0foo'):
         assert func == f
         assert len(args) == 0

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -35,3 +35,13 @@ def test_get_plugins_text_starting_with_u00a0():
     for func, args in p.get_plugins('respond_to', '\u00a0dummy'):
         assert func == f
         assert len(args) == 0
+
+
+def test_get_plugins_text_with_u00a0():
+    p = PluginsManager()
+    f = lambda x: x
+    p.commands['respond_to'][re.compile(r'^dummy foo$')] = f
+    # Calling get_plugins() with `text == None`
+    for func, args in p.get_plugins('respond_to', 'dummy\u00a0foo'):
+        assert func == f
+        assert len(args) == 0

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -36,6 +36,15 @@ def test_get_plugins_text_starting_with_u00a0():
         assert len(args) == 0
 
 
+def test_get_plugins_text_ending_with_u00a0():
+    p = PluginsManager()
+    f = lambda x: x
+    p.commands['respond_to'][re.compile(r'^dummy$')] = f
+    for func, args in p.get_plugins('respond_to', 'dummy\u00a0'):
+        assert func == f
+        assert len(args) == 0
+
+
 def test_get_plugins_text_with_u00a0():
     p = PluginsManager()
     f = lambda x: x

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -25,3 +25,13 @@ def test_get_plugins_none_text():
     for func, args in p.get_plugins('respond_to', None):
         assert func is None
         assert args is None
+
+
+def test_get_plugins_text_starting_with_u00a0():
+    p = PluginsManager()
+    f = lambda x: x
+    p.commands['respond_to'][re.compile(r'^dummy$')] = f
+    # Calling get_plugins() with `text == None`
+    for func, args in p.get_plugins('respond_to', '\u00a0dummy'):
+        assert func == f
+        assert len(args) == 0


### PR DESCRIPTION
When I copy the command posted in slack and execute it, it includes a space character `\u00a0` and it is not recognized correctly.
Therefore, I add the process to remove space characters at the beginning or the ending and to replace a space character with the normal space character from the command before parsing.