### PR TITLE
Do not raise an error if errors_to is None

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -65,10 +65,6 @@ class MessageDispatcher(object):
                         self._client.rtm_send_message(self._errors_to,
                                                       '{}\n{}'.format(reply,
                                                                       tb))
-                    else:
-                        self._client.rtm_send_message(msg['channel'],
-                                                      '{}\n{}'.format(reply,
-                                                                      tb))
         return responded
 
     def _on_new_message(self, msg):


### PR DESCRIPTION
I need a way to disable auto error response to Slack and reply to the user with a custom message like `Your command includes an invalid word`.