### PR TITLE
Run all text through unicode normalization with form NFKD

### DIFF
--- a/slackbot/dispatcher.py
+++ b/slackbot/dispatcher.py
@@ -5,11 +5,12 @@ import logging
 import re
 import time
 import traceback
+import unicodedata
 from functools import wraps
 
 import six
 from slackbot.manager import PluginsManager
-from slackbot.utils import WorkerPool
+from slackbot.utils import WorkerPool, normalize_unicode_text
 from slackbot import settings
 
 logger = logging.getLogger(__name__)
@@ -105,7 +106,7 @@ class MessageDispatcher(object):
         return self._client.login_data['self']['name']
 
     def filter_text(self, msg):
-        full_text = msg.get('text', '') or ''
+        full_text = normalize_unicode_text(msg.get('text', '')) or ''
         channel = msg['channel']
         bot_name = self._get_bot_name()
         bot_id = self._get_bot_id()
@@ -119,7 +120,7 @@ class MessageDispatcher(object):
 
             atuser = matches.get('atuser')
             username = matches.get('username')
-            text = matches.get('text')
+            text = normalize_unicode_text(matches.get('text'))
             alias = matches.get('alias')
 
             if alias:
@@ -133,7 +134,7 @@ class MessageDispatcher(object):
             msg['text'] = text
         else:
             if m:
-                msg['text'] = m.groupdict().get('text', None)
+                msg['text'] = normalize_unicode_text(m.groupdict().get('text', None))
         return msg
 
     def loop(self):

--- a/slackbot/utils.py
+++ b/slackbot/utils.py
@@ -4,6 +4,7 @@ import os
 import logging
 import tempfile
 import requests
+import unicodedata
 from contextlib import contextmanager
 from six.moves import _thread, range, queue
 import six
@@ -23,6 +24,9 @@ def download_file(url, fpath, token=''):
     logger.debug('fetch %s', fpath)
     return fpath
 
+def normalize_unicode_text(s):
+    if s:
+        return unicodedata.normalize("NFKD", s)
 
 def to_utf8(s):
     """Convert a string to utf8. If the argument is an iterable

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -211,3 +211,12 @@ def test_none_text(dispatcher):
     # Should not raise a TypeError
     msg = dispatcher.filter_text(msg)
     assert msg is None
+
+
+def test_non_breaking_spaces_are_removed_from_text(dispatcher):
+    msg = {
+        'text': FAKE_BOT_ATNAME + u"\xa0" + "hello" + u"\xa0" + "world",
+        'channel': 'C99999'
+    }
+    msg = dispatcher.filter_text(msg).get("text")
+    assert msg == "hello world"


### PR DESCRIPTION
In some slack messages non breaking space `u"\xa0"` is used instead of space ` `. This becomes very annoying when matching on regexes.

I believe it would be easier to just normalize the messages as soon as possible to remove the problem.